### PR TITLE
Do not assume PR has commits

### DIFF
--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -651,8 +651,10 @@ class SyncChangeTask(Task):
 
         project_name = remote_change['base']['repo']['full_name']
 
-        remote_checks_data = sync.get('repos/%s/commits/%s/status' % (project_name, remote_commits[-1]['sha']))
-        remote_commits[-1]['_hubtty_remote_checks_data'] = remote_checks_data
+        # PR might have been rebased and no longer contain commits
+        if len(remote_commits) > 0:
+            remote_checks_data = sync.get('repos/%s/commits/%s/status' % (project_name, remote_commits[-1]['sha']))
+            remote_commits[-1]['_hubtty_remote_checks_data'] = remote_checks_data
 
         fetches = collections.defaultdict(list)
         parent_commits = set()


### PR DESCRIPTION
It may be possible that a PR was rebased and no longer contain any
commits. When synchronizing changes, we need to stop assuming PR
contains commits. We don't need the same protection while displaying
changes since github automatically closes PRs without commits and as
a consequence never make it to the change view.

Fixes #24