### PR TITLE
Fix integer and number tokenization

### DIFF
--- a/hubtty/search/__init__.py
+++ b/hubtty/search/__init__.py
@@ -83,6 +83,8 @@ if __name__ == '__main__':
 
     app = Dummy()
     app.config = Dummy()
-    search = SearchCompiler('bob')
+    def my_account():
+      return 1
+    search = SearchCompiler(my_account)
     x = search.parse(query)
     print(x)

--- a/hubtty/search/tokenizer.py
+++ b/hubtty/search/tokenizer.py
@@ -115,12 +115,12 @@ def SearchTokenizer():
         return t
 
     def t_INTEGER(t):
-        r'[+-]\d+'
+        r'[+-]\d+\b'
         t.value = int(t.value)
         return t
 
     def t_NUMBER(t):
-        r'\d+'
+        r'\d+\b'
         t.value = int(t.value)
         return t
 


### PR DESCRIPTION
The tokenization would wrongly break a string starting with a digit (for
instance a SHA) into a number and a string.

Closes #28