### PR TITLE
Rework project sync

### DIFF
--- a/hubtty/alembic/versions/4a2afc48dd09_add_can_push_to_project.py
+++ b/hubtty/alembic/versions/4a2afc48dd09_add_can_push_to_project.py
@@ -1,0 +1,22 @@
+"""Add can_push to project
+
+Revision ID: 4a2afc48dd09
+Revises: 21d691c40b39
+Create Date: 2021-06-05 17:26:00.883182
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4a2afc48dd09'
+down_revision = '21d691c40b39'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('project', sa.Column('can_push', sa.Boolean()))
+
+
+def downgrade():
+    pass

--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -38,6 +38,7 @@ project_table = Table(
     Column('name', String(255), index=True, unique=True, nullable=False),
     Column('subscribed', Boolean, index=True, default=False),
     Column('description', Text, nullable=False, default=''),
+    Column('can_push', Boolean, default=False),
     Column('updated', DateTime),
     )
 branch_table = Table(
@@ -210,10 +211,11 @@ class Account(object):
         self.email = email
 
 class Project(object):
-    def __init__(self, name, subscribed=False, description=''):
+    def __init__(self, name, subscribed=False, description='', can_push=False):
         self.name = name
         self.subscribed = subscribed
         self.description = description
+        self.can_push = can_push
 
     def createChange(self, *args, **kw):
         session = Session.object_session(self)

--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -251,7 +251,7 @@ class SyncProjectListTask(Task):
             elif response.status_code == 404:
                 self.log.error('Project %s does not exist or you do not have '
                         'the permissions to view it.' % additional_repo)
-            elif response.status_code > 400:
+            elif response.status_code >= 400:
                 raise Exception("Received %s status code: %s"
                                 % (response.status_code, response.text))
 
@@ -1428,7 +1428,7 @@ class Sync(object):
         self.log.debug('HTTP status code: %d', response.status_code)
         if response.status_code == 503:
             raise OfflineError("Received 503 status code")
-        elif response.status_code > 400:
+        elif response.status_code >= 400:
             raise Exception("Received %s status code: %s"
                             % (response.status_code, response.text))
 
@@ -1487,7 +1487,7 @@ class Sync(object):
         self.checkResponse(r)
         self.log.debug('Received: %s' % (r.text,))
         ret = None
-        if r.status_code > 400:
+        if r.status_code >= 400:
             raise Exception("POST to %s failed with http code %s (%s)",
                             path, r.status_code, r.text)
         if r.text and len(r.text)>0:

--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -274,8 +274,8 @@ class SyncProjectListTask(Task):
                                                     description=repo_desc)
                     self.log.info("Created project %s", repo_name)
                     self.results.append(ProjectAddedEvent(project))
-                # TODO(mandre) Update description and can_push
-                self.log.info("Can push %s: %s" % (repo_name, remote_repo['permissions']['push']))
+                project.description = repo_desc
+                project.can_push = remote_repo['permissions']['push']
 
             for p in session.getProjects():
                 if p.name not in remote_repos_names:


### PR DESCRIPTION
This allows to update the project that have been modified and makes lay
the foundation for sync of the ability to push changes to projects.

It may be that the repositories added from the config file with
additional-repositories may be private or do not exist. In this case
github returns a 404 and hubtty now discards these repositories.

This is made possible thanks to the introduction of a custom
`response_callback` to the Sync.get() method.

Closes #30