### PR TITLE
Document git-url option

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -63,6 +63,12 @@ line.
     The URL of the Github API server.  HTTPS should be preferred.
     Defaults to https://api.github.com/.
 
+  **git-url**
+    The URL to clone git repos. By default, <url> is used. For a list
+    of valid URLs, see:
+    https://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS
+    Set git-url to ssh://git@github.com in order to clone private repos.
+
   **git-root (required)**
     A location where Hubtty should store its git repositories.  These
     can be the same git repositories where you do your own work --

--- a/examples/openshift-hubtty.yaml
+++ b/examples/openshift-hubtty.yaml
@@ -27,10 +27,10 @@ servers:
 # Hubtty will not modify them unless you tell it to, and even then the
 # normal git protections against losing work remain in place. [required]
 #    git-root: ~/git/
-# The URL to clone git repos. By default, <url>/p/<project> is used. For a list
+# The URL to clone git repos. By default, <url> is used. For a list
 # of valid URLs, see:
 # https://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS
-#    git-url: ssh://user@example.org:29418
+#    git-url: ssh://git@github.com
 # The location of Hubtty's sqlite database.  If you have more than one
 # server, you should specify a dburi for any additional servers.
 # By default a SQLite database called ~/.local/share/hubtty/hubtty.db is used.

--- a/examples/reference-hubtty.yaml
+++ b/examples/reference-hubtty.yaml
@@ -27,10 +27,10 @@ servers:
 # Hubtty will not modify them unless you tell it to, and even then the
 # normal git protections against losing work remain in place. [required]
 #    git-root: ~/git/
-# The URL to clone git repos. By default, <url>/p/<project> is used. For a list
+# The URL to clone git repos. By default, <url> is used. For a list
 # of valid URLs, see:
 # https://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS
-#    git-url: ssh://user@example.org:29418
+#    git-url: ssh://git@github.com
 # The location of Hubtty's sqlite database.  If you have more than one
 # server, you should specify a dburi for any additional servers.
 # By default a SQLite database called ~/.local/share/hubtty/hubtty.db is used.


### PR DESCRIPTION
Explain we need to use `ssh://git@github.com` for cloning private repos,
unless the user caches its credentials as explained in [1]

[1] https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git

Closes #19