### PR TITLE
Drop cherry-pick

### DIFF
--- a/hubtty/alembic/versions/58a0f7616432_drop_pending_cherry_pick_table.py
+++ b/hubtty/alembic/versions/58a0f7616432_drop_pending_cherry_pick_table.py
@@ -1,0 +1,21 @@
+"""Drop pending cherry-pick table
+
+Revision ID: 58a0f7616432
+Revises: 164f2a7ca2b0
+Create Date: 2021-08-09 22:20:18.024213
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '58a0f7616432'
+down_revision = '164f2a7ca2b0'
+
+from alembic import op
+
+
+def upgrade():
+    op.drop_table('pending_cherry_pick')
+
+
+def downgrade():
+    pass

--- a/hubtty/keymap.py
+++ b/hubtty/keymap.py
@@ -56,7 +56,6 @@ TOGGLE_HIDDEN_COMMENTS = 'toggle hidden comments'
 CLOSE_CHANGE = 'close change'
 REOPEN_CHANGE = 'reopen change'
 REBASE_CHANGE = 'rebase change'
-CHERRY_PICK_CHANGE = 'cherry pick change'
 REFRESH = 'refresh'
 EDIT_LABELS = 'edit labels'
 EDIT_PULL_REQUEST = 'edit pull request'
@@ -124,7 +123,6 @@ DEFAULT_KEYMAP = {
     CLOSE_CHANGE: 'meta c',
     REOPEN_CHANGE: 'ctrl e',
     REBASE_CHANGE: 'ctrl b',
-    CHERRY_PICK_CHANGE: 'ctrl x',
     REFRESH: 'ctrl r',
     EDIT_LABELS: 'meta l',
     EDIT_PULL_REQUEST: 'ctrl d',


### PR DESCRIPTION
Github does not yet offer an easy way to cherry-pick a PR to
a different branch [1] and implementing the feature myself is more work
than I'm willing to do at the moment while we're getting towards
a first release. So let's just remove this code for now and revisit
later.

[1] https://github.community/t/do-a-cherry-pick-via-the-api/14573/4