### PR TITLE
Limit sync to 50 comments at a time to workaround github issue

### DIFF
--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -604,7 +604,9 @@ class SyncChangeTask(Task):
         app = sync.app
         remote_change = sync.get('repos/%s' % self.change_id)
         remote_commits = sync.get('repos/%s/commits?per_page=100' % self.change_id)
-        remote_pr_comments = sync.get('repos/%s/comments?per_page=100' % self.change_id)
+        # Limit to 50, as github seems to struggle sending more comments
+        # https://github.com/hubtty/hubtty/issues/59
+        remote_pr_comments = sync.get('repos/%s/comments?per_page=50' % self.change_id)
         remote_pr_reviews = sync.get('repos/%s/reviews?per_page=100' % self.change_id)
         remote_issue_comments = sync.get(('repos/%s/comments?per_page=100'
                                           % self.change_id).replace('/pulls/', '/issues/'))


### PR DESCRIPTION
We've noticed that github API would sometimes return a 502 server error
while querying the `/repos/{owner}/{repo}/pulls/{pull_number}/comments`
endpoint [1] with a high per_page value.

To workaround the issue, we decrease the per_page value to 50.

Fixes #59

[1] https://docs.github.com/en/rest/reference/pulls#list-review-comments-on-a-pull-request