### PR TITLE
Do not sync closed changes unless they are in local db

### DIFF
--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -848,7 +848,7 @@ class DatabaseSession(object):
         # locally with the remote changes.
         if not ids:
             return set()
-        query = self.session().query(Change.id)
+        query = self.session().query(Change.change_id)
         return set(ids).intersection(r[0] for r in query.all())
 
     def getChangesByChangeID(self, change_id):


### PR DESCRIPTION
Only sync changes that are new, or already in the local database.
This will skip all changes that were closed in the remote repo before we
got a chance to pull them locally. This will help speeding up sync when
syncing after a long period.

Based on gertty's implementation that I left out originally.

Fix the getChangeIDs() function to look at change_id, the real change
identifier.