### PR TITLE
Force dates to be specified with month at least

### DIFF
--- a/hubtty/search/tokenizer.py
+++ b/hubtty/search/tokenizer.py
@@ -100,11 +100,11 @@ def SearchTokenizer():
         return t
 
     def t_DATE(t):
-        r'\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?'
+        r'\d{4}-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?'
         return t
 
     def t_DATECOMP(t):
-        r'[<>]=?\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?'
+        r'[<>]=?\d{4}-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?'
         return t
 
     def t_AND(t):


### PR DESCRIPTION
A date with only four digits is valid in ISO 8601 and represents a year,
however this caused all integers between 999 and 9999 to be parsed as
dates.

To workaround the issue, let's force dates to at least contain the
month, in the form YYYY-MM.

Fixes #70