### PR TITLE
Fix multiple issues with reviews

### DIFF
--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -805,6 +805,7 @@ class App(object):
         existing_approval = session.getApproval(pr, account, commit.sha)
         if existing_approval:
             existing_approval.draft = True
+            existing_approval.state = approval
         else:
             pr.createApproval(account, approval, commit.sha, draft=True)
 

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -808,9 +808,7 @@ class App(object):
         else:
             pr.createApproval(account, approval, commit.sha, draft=True)
 
-        draft_message = commit.getPendingMessage()
-        if not draft_message:
-            draft_message = commit.getDraftMessage()
+        draft_message = commit.getDraftMessage()
         if not draft_message:
             if message or upload:
                 draft_message = pr.createMessage(commit.key, None, account,

--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -449,11 +449,11 @@ class Commit(object):
                 self._file_cache[f.path] = f
         return self._file_cache.get(path, None)
 
-    def getPendingMessage(self):
+    def hasPendingMessage(self):
         for m in self.messages:
             if m.pending:
-                return m
-        return None
+                return True
+        return False
 
     def getDraftMessage(self):
         for m in self.messages:

--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -395,6 +395,9 @@ class PullRequest(object):
         self.labels.remove(label)
         session.flush()
 
+    def hasPendingMessage(self):
+        return self.isValid() and self.commits[-1].hasPendingMessage()
+
     def isValid(self):
         # This might happen when the sync was partial, i.e. we hit rate limit
         # or the connection dropped

--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -632,6 +632,7 @@ mapper(RepositoryTopic, repository_topic_table)
 mapper(PullRequest, pull_request_table, properties=dict(
         author=relationship(Account),
         commits=relationship(Commit, backref='pull_request',
+                             order_by=commit_table.c.key,
                              cascade='all, delete-orphan'),
         messages=relationship(Message, backref='pull_request',
                               order_by=message_table.c.created,

--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -782,7 +782,9 @@ class SyncPullRequestTask(Task):
                 if review_state:
                     approval = session.getApproval(pr, account, remote_review.get('commit_id'))
                     if approval:
-                        approval.state = review_state
+                        # Only update approval if it hasn't been changed locally
+                        if not approval.draft:
+                            approval.state = review_state
                     else:
                         pr.createApproval(account, review_state, remote_review.get('commit_id'))
                         self.log.info("Created new approval for %s from %s commit %s.", pr.pr_id, account.username, remote_review.get('commit_id'))

--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -808,7 +808,7 @@ class SyncPullRequestTask(Task):
                 if not comment:
                     created = dateutil.parser.parse(remote_comment['created_at'])
                     parent = False
-                    if remote_comment.get('side', '') == 'PARENT':
+                    if remote_comment.get('side', '') == 'LEFT':
                         parent = True
                     message = session.getMessageByID(remote_comment['pull_request_review_id'])
 
@@ -1104,7 +1104,7 @@ class UploadReviewTask(Task):
                                  line=comment.line,
                                  body=comment.message)
                         if comment.parent:
-                            d['side'] = 'PARENT'
+                            d['side'] = 'LEFT'
                         comments.append(d)
                         session.delete(comment)
             if comments:

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -466,11 +466,12 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
         with self.app.db.getSession() as session:
             account = session.getOwnAccount()
             pr = session.getPullRequest(self.pr_key)
+            latest_pr_commit = pr.commits[-1]
             commit = session.getCommit(self.new_commit_key)
 
-            message = commit.getDraftMessage()
+            message = latest_pr_commit.getDraftMessage()
             if not message:
-                message = pr.createMessage(commit.key, None, account,
+                message = pr.createMessage(latest_pr_commit.key, None, account,
                                            datetime.datetime.utcnow(),
                                            '', draft=True)
             comment = message.createComment(file_key, None, account, None,

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -468,7 +468,7 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             pr = session.getPullRequest(self.pr_key)
             commit = session.getCommit(self.new_commit_key)
 
-            message = commit.getPendingMessage()
+            message = commit.getDraftMessage()
             if not message:
                 message = pr.createMessage(commit.key, None, account,
                                            datetime.datetime.utcnow(),

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -335,7 +335,7 @@ class CommitRow(urwid.WidgetWrap):
                 ('commit-name', ' %s' % commit.message.split('\n')[0])]
         num_drafts = sum([len(f.draft_comments) for f in commit.files])
         if num_drafts:
-            if not commit.hasPendingMessage():
+            if not commit.pull_request.hasPendingMessage():
                 line.append(('commit-drafts', ' (%s draft%s)' % (
                             num_drafts, num_drafts>1 and 's' or '')))
         num_comments = sum([len(f.current_comments) for f in commit.files]) - num_drafts
@@ -725,7 +725,7 @@ class PullRequestView(urwid.WidgetWrap):
                 approval_headers.append(urwid.Text(('table-header', state)))
             votes = mywid.Table(approval_headers)
             approvals_for_account = {}
-            pending_message = pr.commits[-1].hasPendingMessage()
+            pending_message = pr.hasPendingMessage()
             for approval in pr.approvals:
                 # Don't display draft approvals unless they are pending-upload
                 if approval.draft and not pending_message:

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -116,9 +116,7 @@ class ReviewDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
                         b = urwid.AttrMap(b, 'negative-label')
                     rows.append(b)
                 rows.append(urwid.Divider())
-            m = commit.getPendingMessage()
-            if not m:
-                m = commit.getDraftMessage()
+            m = commit.getDraftMessage()
             if m:
                 message = m.message
         self.message = mywid.MyEdit(u"Message: \n", edit_text=message,

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -100,10 +100,18 @@ class ReviewDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
             if commit == pr.commits[-1]:
                 current = None
                 for approval in pr.approvals:
+                    if approval.sha != commit.sha:
+                        continue
                     if self.app.isOwnAccount(approval.reviewer):
                         current = approval.state
+                        if current == 'APPROVED':
+                            current = 'APPROVE'
+                        elif current == 'CHANGES_REQUESTED':
+                            current = 'REQUEST_CHANGES'
+                        elif current == 'COMMENTED':
+                            current = 'COMMENT'
                         break
-                if current is None:
+                if current is None or current == '':
                     current = 'COMMENT'
 
                 rows.append(urwid.Text('Review changes:'))

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -829,7 +829,7 @@ class PullRequestView(urwid.WidgetWrap):
                     self.message_rows[message.key] = row
                 else:
                     unseen_keys.remove(message.key)
-                    if message.created != row.original_widget.message_created:
+                    if message.draft or message.created != row.original_widget.message_created:
                         row.original_widget.refresh(pr, message)
                 listbox_index += 1
             # Remove any messages that should not be displayed

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -257,16 +257,16 @@ class ReviewButton(mywid.FixedButton):
                                    self.commit_row.commit_key,
                                    message=message)
         urwid.connect_signal(self.dialog, 'save',
-            lambda button: self.closeReview(True, False))
+            lambda button: self.closeReview(upload=True, merge=False))
         urwid.connect_signal(self.dialog, 'merge',
-            lambda button: self.closeReview(True, True))
+            lambda button: self.closeReview(upload=True, merge=True))
         urwid.connect_signal(self.dialog, 'cancel',
-            lambda button: self.closeReview(False, False))
+            lambda button: self.closeReview(upload=False, merge=False))
         self.pr_view.app.popup(self.dialog,
                                relative_width=50, relative_height=75,
                                min_width=60, min_height=20)
 
-    def closeReview(self, upload, merge):
+    def closeReview(self, upload=False, merge=False):
         approval, message = self.dialog.getValues()
         self.pr_view.saveReview(self.commit_row.commit_key, approval,
                                     message, upload, False)

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -735,9 +735,6 @@ class PullRequestView(urwid.WidgetWrap):
             approvals_for_account = {}
             pending_message = pr.hasPendingMessage()
             for approval in pr.approvals:
-                # Don't display draft approvals unless they are pending-upload
-                if approval.draft and not pending_message:
-                    continue
                 approvals = approvals_for_account.get(approval.reviewer.id)
                 if not approvals:
                     approvals = {}
@@ -756,11 +753,20 @@ class PullRequestView(urwid.WidgetWrap):
                 # Only set approval status if the review is for the current commit
                 if approval.sha == pr.commits[-1].sha:
                     if approval.state in ['APPROVED', 'APPROVE']:
-                        approvals['Approved'].set_text(('positive-label', '✓'))
+                        text = '✓'
+                        if approval.state == 'APPROVE' and not pending_message:
+                            text = '(' + text + ')'
+                        approvals['Approved'].set_text(('positive-label', text))
                     elif approval.state in ['CHANGES_REQUESTED', 'REQUEST_CHANGES']:
-                        approvals['Changes Requested'].set_text(('negative-label', '✗'))
+                        text = '✗'
+                        if approval.state == 'REQUEST_CHANGES' and not pending_message:
+                            text = '(' + text + ')'
+                        approvals['Changes Requested'].set_text(('negative-label', text))
                     else:
-                        approvals['Comment'].set_text('•')
+                        text = '•'
+                        if approval.state == 'COMMENT' and not pending_message:
+                            text = '(' + text + ')'
+                        approvals['Comment'].set_text(text)
             votes = urwid.Padding(votes, width='pack')
 
             # TODO: update the existing table rather than replacing it

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -335,8 +335,7 @@ class CommitRow(urwid.WidgetWrap):
                 ('commit-name', ' %s' % commit.message.split('\n')[0])]
         num_drafts = sum([len(f.draft_comments) for f in commit.files])
         if num_drafts:
-            pending_message = commit.getPendingMessage()
-            if not pending_message:
+            if not commit.hasPendingMessage():
                 line.append(('commit-drafts', ' (%s draft%s)' % (
                             num_drafts, num_drafts>1 and 's' or '')))
         num_comments = sum([len(f.current_comments) for f in commit.files]) - num_drafts
@@ -726,7 +725,7 @@ class PullRequestView(urwid.WidgetWrap):
                 approval_headers.append(urwid.Text(('table-header', state)))
             votes = mywid.Table(approval_headers)
             approvals_for_account = {}
-            pending_message = pr.commits[-1].getPendingMessage()
+            pending_message = pr.commits[-1].hasPendingMessage()
             for approval in pr.approvals:
                 # Don't display draft approvals unless they are pending-upload
                 if approval.draft and not pending_message:

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -126,7 +126,10 @@ class ReviewDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
                 rows.append(urwid.Divider())
             m = commit.getDraftMessage()
             if m:
-                message = m.message
+                if message:
+                    message = message + "\n" + m.message
+                else:
+                    message = m.message
         self.message = mywid.MyEdit(u"Message: \n", edit_text=message,
                                     multiline=True, ring=app.ring)
         rows.append(self.message)


### PR DESCRIPTION
The patch series fixes a number of issues with reviews. The most critical were:
- only comments to the last commit were uploaded
- it would send PR review with the wrong status if it already had an approval
- leaving comment on the deleted diff would trigger an error

In addition, this includes many small UX improvements.