### PR TITLE
Import alembic.migration

### DIFF
--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -20,6 +20,7 @@ import threading
 
 import alembic
 import alembic.config
+import alembic.migration
 import six
 import sqlalchemy
 from sqlalchemy import create_engine, MetaData, Table, Column, Integer, String, Boolean, DateTime, Text, UniqueConstraint


### PR DESCRIPTION
This is needed for alembic >=1.7, though unfortunately goes entirely
unmentioned in its ChangeLog. Without adding the import, startup
raises this:

    AttributeError: module 'alembic' has no attribute 'migration'

Port commit bff537e87c from opendev.org/ttygroup/gertty