### PR TITLE
Support draft PRs

### DIFF
--- a/hubtty/alembic/versions/1e41885ea284_add_draft_to_pull_request.py
+++ b/hubtty/alembic/versions/1e41885ea284_add_draft_to_pull_request.py
@@ -1,0 +1,37 @@
+"""Add draft to pull-request
+
+Revision ID: 1e41885ea284
+Revises: a2af1e2e44ee
+Create Date: 2022-01-21 10:07:48.605105
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1e41885ea284'
+down_revision = 'a2af1e2e44ee'
+
+from alembic import op
+import sqlalchemy as sa
+
+import warnings
+
+from hubtty.dbsupport import sqlite_alter_columns
+
+
+def upgrade():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        op.add_column('pull_request', sa.Column('draft', sa.Boolean()))
+
+    connection = op.get_bind()
+    pr = sa.sql.table('pull_request',
+            sa.sql.column('draft', sa.Boolean()))
+    connection.execute(pr.update().values({'draft':False}))
+
+    sqlite_alter_columns('pull_request', [
+        sa.Column('draft', sa.Boolean(), index=True, nullable=False),
+        ])
+
+
+def downgrade():
+    pass

--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -91,6 +91,7 @@ pull_request_table = Table(
     Column('outdated', Boolean, index=True, nullable=False),
     Column('merged', Boolean, index=True, nullable=False),
     Column('mergeable', Boolean, index=True, nullable=False),
+    Column('draft', Boolean, index=True, nullable=False),
     )
 commit_table = Table(
     'commit', metadata,
@@ -295,10 +296,11 @@ class PullRequestLabel(object):
 class PullRequest(object):
     def __init__(self, repository, id, author, number, branch, pr_id,
                  title, body, created, updated, state, additions, deletions,
-                 html_url, merged, mergeable, hidden=False, reviewed=False,
-                 starred=False, held=False, pending_rebase=False,
-                 pending_edit=False, pending_edit_message=None,
-                 pending_labels=False, outdated=False):
+                 html_url, merged, mergeable, draft=False, hidden=False,
+                 reviewed=False, starred=False, held=False,
+                 pending_rebase=False, pending_edit=False,
+                 pending_edit_message=None, pending_labels=False,
+                 outdated=False):
         self.repository_key = repository.key
         self.account_key = author.key
         self.id = id
@@ -310,6 +312,7 @@ class PullRequest(object):
         self.created = created
         self.updated = updated
         self.state = state
+        self.draft = draft
         self.additions = additions
         self.deletions = deletions
         self.html_url = html_url

--- a/hubtty/palette.py
+++ b/hubtty/palette.py
@@ -77,6 +77,7 @@ DEFAULT_PALETTE={
     'check-success': ['light green', ''],
     'check-failure': ['light red', ''],
     'check-pending': ['dark magenta', ''],
+    'state-draft': ['yellow', ''],
     # repository list
     'unreviewed-repository': ['white', ''],
     'subscribed-repository': ['default', ''],

--- a/hubtty/search/parser.py
+++ b/hubtty/search/parser.py
@@ -95,6 +95,7 @@ def SearchParser():
                 | in_term
                 | is_term
                 | state_term
+                | draft_term
                 | file_term
                 | path_term
                 | limit_term
@@ -427,6 +428,15 @@ def SearchParser():
         elif p[2] == 'unmerged' or p[2] == 'abandoned':
             p[0] = and_(hubtty.db.pull_request_table.c.state == 'closed',
                         hubtty.db.pull_request_table.c.merged == False)
+        else:
+            p[0] = hubtty.db.pull_request_table.c.state == p[2]
+
+    def p_draft_term(p):
+        '''draft_term : OP_DRAFT string'''
+        if p[2] == 'true':
+            p[0] = hubtty.db.pull_request_table.c.draft == True
+        elif p[2] == 'false':
+            p[0] = hubtty.db.pull_request_table.c.draft == False
         else:
             p[0] = hubtty.db.pull_request_table.c.state == p[2]
 

--- a/hubtty/search/tokenizer.py
+++ b/hubtty/search/tokenizer.py
@@ -42,6 +42,7 @@ operators = {
     'in': 'OP_IN',
     'is': 'OP_IS',
     'state': 'OP_STATE',
+    'draft': 'OP_DRAFT',
     'limit': 'OP_LIMIT',
     'label': 'OP_LABEL',
     }

--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -680,6 +680,7 @@ class SyncPullRequestTask(Task):
                                                   remote_pr['html_url'],
                                                   remote_pr['merged'],
                                                   (remote_pr['mergeable'] or False),
+                                                  remote_pr['draft'],
                                                   )
                 self.log.info("Created new pull request %s in local DB.", pr.pr_id)
                 result = PullRequestAddedEvent(pr)
@@ -698,6 +699,7 @@ class SyncPullRequestTask(Task):
             pr.deletions = remote_pr['deletions']
             pr.merged = remote_pr['merged']
             pr.mergeable = remote_pr.get('mergeable') or False
+            pr.draft = remote_pr['draft']
 
             for label in remote_pr['labels']:
                 l = session.getLabel(label['id'])

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -725,7 +725,8 @@ class PullRequestView(urwid.WidgetWrap):
             self.labels_label.set_text(('pr-data', label_buttons or u''))
             self.created_label.set_text(('pr-data', str(self.app.time(pr.created))))
             self.updated_label.set_text(('pr-data', str(self.app.time(pr.updated))))
-            self.status_label.set_text(('pr-data', pr.state))
+            stat = pr.draft and ('state-draft', 'Draft') or pr.state
+            self.status_label.set_text(('pr-data', stat))
             self.permalink_url = str(pr.html_url)
             self.permalink_label.text.set_text(('pr-data', self.permalink_url))
             self.pr_description.set_text('\n'.join([pr.title, '', pr.body]))


### PR DESCRIPTION
Based on gertty's commits 94310529ed and 363114eb7a.

Sadly, the github REST API does not yet allow changing the draft status
of the PRs [1] so we're limiting ourselves to showing draft PRs. We
would have to use their GraphQL API [2] for changing the draft status of
PRs, similar to what the github CLI client does [3].

It's also now possible to search for PRs based on their draft status with the
`draft: true` and `draft: false` queries.

Fixes #41.