### PR TITLE
Render markdown comments and PR description

### DIFF
--- a/hubtty/markdown.py
+++ b/hubtty/markdown.py
@@ -67,10 +67,8 @@ class Renderer:
             elif element['type'] == 'list_item':
                 text.extend(self.toUrwidMarkup(element['children']))
             elif element['type'] == 'block_text':
-                block_text = ""
-                for child in element['children']:
-                    block_text += child['text']
-                text.append("%s\n" % block_text)
+                text.extend(self.toUrwidMarkup(element['children']))
+                text.append("\n")
             elif element['type'] == 'link':
                 url = element['link']
                 link_text = ""

--- a/hubtty/markdown.py
+++ b/hubtty/markdown.py
@@ -75,7 +75,10 @@ class Renderer:
                 url = element['link']
                 link_text = ""
                 for child in element['children']:
-                    link_text += child['text']
+                    if child.get('text'):
+                        link_text += child['text']
+                    elif child.get('alt'):
+                        link_text += child['alt']
                 link = mywid.Link(link_text, 'link', 'focused-link')
                 urwid.connect_signal(link, 'selected',
                     lambda link:self.app.openURL(url))

--- a/hubtty/markdown.py
+++ b/hubtty/markdown.py
@@ -44,7 +44,10 @@ class Renderer:
             elif element['type'] == 'block_quote':
                 text.append(('md-blockquote', ["| ", self.toUrwidMarkup(element['children'])]))
             elif element['type'] == 'block_code':
-                text.append(('md-blockcode', ["```%s\n" % element.get('info'), element['text'], "```\n"]))
+                info = element['info']
+                if info == None:
+                    info = ""
+                text.append(('md-blockcode', ["```%s\n" % info, element['text'], "```\n"]))
             elif element['type'] == 'block_html':
                 # HTML comments - do nothing
                 pass

--- a/hubtty/markdown.py
+++ b/hubtty/markdown.py
@@ -90,5 +90,8 @@ class Renderer:
 
     def render(self, text):
         md = mistune.create_markdown(renderer=mistune.AstRenderer(), plugins=['strikethrough'])
+        # Misture returns newline for empty text, we don't want that
+        if not text:
+            return []
         ast = md(text)
         return self.toUrwidMarkup(ast)

--- a/hubtty/markdown.py
+++ b/hubtty/markdown.py
@@ -1,0 +1,90 @@
+# Copyright 2022 Martin André
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import mistune
+import urwid
+
+from hubtty import mywid
+
+class Renderer:
+    def __init__(self, app):
+        self.log = logging.getLogger('hubtty.markdown')
+        self.app = app
+
+    def toUrwidMarkup(self, ast):
+        text = []
+        for element in ast:
+            if element['type'] == 'text':
+                text.append(element['text'])
+            elif element['type'] == 'strong':
+                text.append(('md-strong', self.toUrwidMarkup(element['children'])))
+            elif element['type'] == 'emphasis':
+                text.append(('md-emphasis', self.toUrwidMarkup(element['children'])))
+            elif element['type'] == 'strikethrough':
+                text.append(('md-strikethrough', self.toUrwidMarkup(element['children'])))
+            elif element['type'] == 'heading':
+                text.append(('md-heading', ["#" * element['level'], " ", self.toUrwidMarkup(element['children']), "\n"]))
+            elif element['type'] == 'paragraph':
+                text.extend(self.toUrwidMarkup(element['children']))
+                text.append("\n")
+            elif element['type'] == 'newline':
+                text.append("\n")
+            elif element['type'] == 'block_quote':
+                text.append(('md-blockquote', ["| ", self.toUrwidMarkup(element['children'])]))
+            elif element['type'] == 'block_code':
+                text.append(('md-blockcode', ["```%s\n" % element.get('info'), element['text'], "```\n"]))
+            elif element['type'] == 'block_html':
+                # HTML comments - do nothing
+                pass
+            elif element['type'] == 'codespan':
+                text.append(('md-codespan', element['text']))
+            elif element['type'] == 'list':
+                if element['ordered']:
+                    idx = 1
+                    for li in element['children']:
+                        text.append("  " * element['level'] + "%s. " % idx)
+                        text.extend(self.toUrwidMarkup([li]))
+                        idx += 1
+                else:
+                    for li in element['children']:
+                        text.append("  " * element['level'] + "- ")
+                        text.extend(self.toUrwidMarkup([li]))
+            elif element['type'] == 'list_item':
+                text.extend(self.toUrwidMarkup(element['children']))
+            elif element['type'] == 'block_text':
+                block_text = ""
+                for child in element['children']:
+                    block_text += child['text']
+                text.append("%s\n" % block_text)
+            elif element['type'] == 'link':
+                url = element['link']
+                link_text = ""
+                for child in element['children']:
+                    link_text += child['text']
+                link = mywid.Link(link_text, 'link', 'focused-link')
+                urwid.connect_signal(link, 'selected',
+                    lambda link:self.app.openURL(url))
+                text.append(link)
+            else:
+                self.log.warning("unknown element type: %s" % element['type'])
+                if 'children' in element:
+                    text.extend(self.toUrwidMarkup(element['children']))
+        return text
+        
+
+    def render(self, text):
+        md = mistune.create_markdown(renderer=mistune.AstRenderer(), plugins=['strikethrough'])
+        ast = md(text)
+        return self.toUrwidMarkup(ast)

--- a/hubtty/palette.py
+++ b/hubtty/palette.py
@@ -119,6 +119,14 @@ DEFAULT_PALETTE={
     'focused-line-count-threshold-7': ['dark red,standout', ''],
     'line-count-threshold-8': ['light red', ''],
     'focused-line-count-threshold-8': ['light red,standout', ''],
+    # Markdown
+    'md-strong': ['bold', ''],
+    'md-emphasis': ['italics', ''],
+    'md-heading': ['underline,bold', ''],
+    'md-blockquote': ['light gray', ''],
+    'md-blockcode': ['', 'dark gray'],
+    'md-codespan': ['standout', ''],
+    'md-strikethrough': ['strikethrough', ''],
     }
 
 # A delta from the default palette

--- a/hubtty/palette.py
+++ b/hubtty/palette.py
@@ -125,7 +125,7 @@ DEFAULT_PALETTE={
     'md-heading': ['underline,bold', ''],
     'md-blockquote': ['light gray', ''],
     'md-blockcode': ['', 'dark gray'],
-    'md-codespan': ['standout', ''],
+    'md-codespan': ['', 'dark gray'],
     'md-strikethrough': ['strikethrough', ''],
     }
 

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -504,7 +504,12 @@ class PullRequestMessageBox(mywid.HyperText):
                 if location_str:
                     location_str += ": "
                 comment_text.append(u'\n  %s' % (location_str))
-                comment_text.extend(self.md.render(comment))
+                # Let's pass the rendered comment through commentlinks, but not
+                # location_str
+                rendered_comment = self.md.render(comment)
+                for commentlink in self.app.config.commentlinks:
+                    rendered_comment = commentlink.run(self.app, rendered_comment)
+                comment_text.extend(rendered_comment)
                 comment_text.append('\n')
 
         self.set_text(text+comment_text)

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -592,6 +592,7 @@ class PullRequestView(urwid.WidgetWrap):
         self.updated_label = urwid.Text(u'', wrap='clip')
         self.status_label = urwid.Text(u'', wrap='clip')
         self.permalink_label = mywid.TextButton(u'', on_press=self.openPermalink)
+        self.md = markdown.Renderer(self.app)
         pr_info = []
         pr_info_map={'pr-data': 'focused-pr-data'}
         for l, v in [("Author", urwid.Padding(urwid.AttrMap(self.author_label, None,
@@ -729,7 +730,7 @@ class PullRequestView(urwid.WidgetWrap):
             self.status_label.set_text(('pr-data', stat))
             self.permalink_url = str(pr.html_url)
             self.permalink_label.text.set_text(('pr-data', self.permalink_url))
-            self.pr_description.set_text('\n'.join([pr.title, '', pr.body]))
+            self.pr_description.set_text(["%s\n\n" % pr.title] + self.md.render(pr.body))
 
             review_states = ['Changes Requested', 'Comment', 'Approved']
             approval_headers = [urwid.Text(('table-header', 'Name'))]

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -445,7 +445,6 @@ class PullRequestMessageBox(mywid.HyperText):
         self.message_author = message.author_name
         self.message_text = message.message
         created = self.app.time(message.created)
-        comment_text = self.md.render("\n%s" % message.message)
         if self.app.isOwnAccount(message.author):
             name_style = 'pr-message-own-name'
             header_style = 'pr-message-own-header'
@@ -474,6 +473,12 @@ class PullRequestMessageBox(mywid.HyperText):
             text.append(' ')
             text.append(link)
 
+        comment_text = self.md.render(message.message)
+        if len(comment_text) > 0:
+            if isinstance(comment_text[0], tuple):
+                comment_text = ["\n"] + comment_text
+            else:
+                comment_text[0] = "\n%s" % comment_text[0]
         for commentlink in self.app.config.commentlinks:
             comment_text = commentlink.run(self.app, comment_text)
 

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -515,7 +515,8 @@ class PrDescriptionBox(mywid.HyperText):
         super(PrDescriptionBox, self).__init__(message)
 
     def set_text(self, text):
-        text = [text]
+        if len(text) == 0:
+            text = [text]
         for commentlink in self.app.config.commentlinks:
             text = commentlink.run(self.app, text)
         super(PrDescriptionBox, self).set_text(text)

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -445,7 +445,7 @@ class PullRequestMessageBox(mywid.HyperText):
         self.message_author = message.author_name
         self.message_text = message.message
         created = self.app.time(message.created)
-        lines = message.message.split('\n')
+        comment_text = self.md.render("\n%s" % message.message)
         if self.app.isOwnAccount(message.author):
             name_style = 'pr-message-own-name'
             header_style = 'pr-message-own-header'
@@ -474,10 +474,6 @@ class PullRequestMessageBox(mywid.HyperText):
             text.append(' ')
             text.append(link)
 
-        if lines and lines[-1]:
-            lines.insert(0, '')
-            lines.append('')
-        comment_text = ['\n'.join(lines)]
         for commentlink in self.app.config.commentlinks:
             comment_text = commentlink.run(self.app, comment_text)
 

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -28,6 +28,7 @@ from hubtty import gitrepo
 from hubtty import keymap
 from hubtty import mywid
 from hubtty import sync
+from hubtty import markdown
 from hubtty.view import side_diff as view_side_diff
 from hubtty.view import unified_diff as view_unified_diff
 from hubtty.view import mouse_scroll_decorator
@@ -398,6 +399,7 @@ class PullRequestMessageBox(mywid.HyperText):
         super(PullRequestMessageBox, self).__init__(u'')
         self.pr_view = pr_view
         self.app = pr_view.app
+        self.md = markdown.Renderer(self.app)
         self.refresh(pr, message)
 
     def formatReply(self):
@@ -500,7 +502,9 @@ class PullRequestMessageBox(mywid.HyperText):
                     location_str += str(line)
                 if location_str:
                     location_str += ": "
-                comment_text.append(u'\n  %s%s\n' % (location_str, comment))
+                comment_text.append(u'\n  %s' % (location_str))
+                comment_text.extend(self.md.render(comment))
+                comment_text.append('\n')
 
         self.set_text(text+comment_text)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ voluptuous>=0.7
 ply>=3.4
 six
 pyxdg
+mistune


### PR DESCRIPTION
This PR adds support for rendering markdown.

We use the Mistune python markdown parser [1] to generate AST that we
then convert into Urwid text markup. Users can customize the appearance
of the markdown elements via the appropriate palette attributes.

Unfortunately, nested markups can sometimes cause graphical issues due to a bug in urwid [2].
This could be the case for example with quoted text containing markup.

[1] https://mistune.readthedocs.io/en/latest/
[2] https://github.com/urwid/urwid/issues/303