### PR TITLE
Show colored labels for terminal that support it

### DIFF
--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -340,16 +340,7 @@ class App(object):
         self.loop.screen.set_terminal_properties(colors=2**24)
         with self.db.getSession() as session:
             for label in session.getLabels():
-                name = "label" + str(label.id)
-                color = "#" + str(label.color)
-                r,g,b = tuple(int(label.color[i:i+2], 16) for i in (0, 2, 4))
-                _,l,_ = colorsys.rgb_to_hls(r, g, b)
-                if l > 100:
-                    fg = "#111"
-                else:
-                    fg = "#eee"
-                self.loop.screen.register_palette_entry(name, '', 'dark cyan', foreground_high=fg, background_high=color)
-
+                self.registerPaletteEntry(label.id, label.color)
 
         self.startSocketListener()
 
@@ -361,6 +352,17 @@ class App(object):
             self.sync_thread = None
             self.sync.offline = True
             self.status.update(offline=True)
+
+    def registerPaletteEntry(self, label_id, label_color):
+        name = "label_" + str(label_id)
+        color = "#" + str(label_color)
+        r,g,b = tuple(int(label_color[i:i+2], 16) for i in (0, 2, 4))
+        _,l,_ = colorsys.rgb_to_hls(r, g, b)
+        if l > 110:
+            fg = "#111"
+        else:
+            fg = "#eee"
+        self.loop.screen.register_palette_entry(name, '', 'dark cyan', foreground_high=fg, background_high=color)
 
     def getOwnAccountId(self):
         return self.own_account_id

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -337,7 +337,8 @@ class App(object):
             self.welcome()
 
         self.loop.screen.tty_signal_keys(start='undefined', stop='undefined')
-        self.loop.screen.set_terminal_properties(colors=2**24)
+        if os.environ.get('COLORTERM') == 'truecolor':
+            self.loop.screen.set_terminal_properties(colors=2**24)
         with self.db.getSession() as session:
             for label in session.getLabels():
                 self.registerPaletteEntry(label.id, label.color)

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -14,6 +14,7 @@
 # under the License.
 
 import argparse
+import colorsys
 import datetime
 import dateutil
 import fcntl
@@ -341,7 +342,13 @@ class App(object):
             for label in session.getLabels():
                 name = "label" + str(label.id)
                 color = "#" + str(label.color)
-                self.loop.screen.register_palette_entry(name, '', 'dark cyan', background_high=color)
+                r,g,b = tuple(int(label.color[i:i+2], 16) for i in (0, 2, 4))
+                _,l,_ = colorsys.rgb_to_hls(r, g, b)
+                if l > 100:
+                    fg = "#111"
+                else:
+                    fg = "#eee"
+                self.loop.screen.register_palette_entry(name, '', 'dark cyan', foreground_high=fg, background_high=color)
 
 
         self.startSocketListener()

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -336,7 +336,13 @@ class App(object):
             self.welcome()
 
         self.loop.screen.tty_signal_keys(start='undefined', stop='undefined')
-        #self.loop.screen.set_terminal_properties(colors=88)
+        self.loop.screen.set_terminal_properties(colors=2**24)
+        with self.db.getSession() as session:
+            for label in session.getLabels():
+                name = "label" + str(label.id)
+                color = "#" + str(label.color)
+                self.loop.screen.register_palette_entry(name, '', 'dark cyan', background_high=color)
+
 
         self.startSocketListener()
 

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -356,13 +356,15 @@ class App(object):
     def registerPaletteEntry(self, label_id, label_color):
         name = "label_" + str(label_id)
         color = "#" + str(label_color)
+        # Get the luminance of the color. We convert hex to RGB, then RGB to HLS.
         r,g,b = tuple(int(label_color[i:i+2], 16) for i in (0, 2, 4))
         _,l,_ = colorsys.rgb_to_hls(r, g, b)
         if l > 110:
             fg = "#111"
         else:
             fg = "#eee"
-        self.loop.screen.register_palette_entry(name, '', 'dark cyan', foreground_high=fg, background_high=color)
+        default_fg, default_bg = self.config.palette.getPaletteItem('pr-data')
+        self.loop.screen.register_palette_entry(name, default_fg, default_bg, foreground_high=fg, background_high=color)
 
     def getOwnAccountId(self):
         return self.own_account_id

--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -1033,6 +1033,9 @@ class DatabaseSession(object):
         except sqlalchemy.orm.exc.NoResultFound:
             return None
 
+    def getLabels(self):
+        return self.session().query(Label).all()
+
     def createRepository(self, *args, **kw):
         o = Repository(*args, **kw)
         self.session().add(o)

--- a/hubtty/palette.py
+++ b/hubtty/palette.py
@@ -173,3 +173,6 @@ class Palette(object):
         for k,v in self.palette.items():
             ret.append(tuple([k]+v))
         return ret
+
+    def getPaletteItem(self, name):
+        return self.palette.get(name, ['',''])

--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -375,6 +375,7 @@ class SyncRepositoryLabelsTask(Task):
                     self.log.info("Created label %s for repository %s", remote_label['name'], repository.name)
                     repository.createLabel(remote_label['id'], remote_label['name'],
                             remote_label['color'], remote_label['description'])
+                    app.registerPaletteEntry(remote_label['id'], remote_label['color'])
                 else:
                     label.name = remote_label['name']
                     label.color = remote_label['color']

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -729,7 +729,7 @@ class PullRequestView(urwid.WidgetWrap):
             for x in pr.labels:
                 if label_buttons:
                     label_buttons.append(', ')
-                label_name = "label" + str(x.id)
+                label_name = "label_" + str(x.id)
                 link = mywid.Link(x.name, label_name, 'focused-pr-data')
                 urwid.connect_signal(
                     link, 'selected',

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -58,7 +58,9 @@ class EditLabelsDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
 
         rows.append(urwid.Text(u"Labels:"))
         for label in pr.repository.labels:
+            palette_item = "label_" + str(label.id)
             b = mywid.FixedCheckBox(label.name, state=(label in pr.labels))
+            b.set_label((palette_item, label.name))
             rows.append(b)
             self.labels_checkboxes.append(b)
         rows.append(urwid.Divider())

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -729,7 +729,8 @@ class PullRequestView(urwid.WidgetWrap):
             for x in pr.labels:
                 if label_buttons:
                     label_buttons.append(', ')
-                link = mywid.Link(x.name, 'pr-data', 'focused-pr-data')
+                label_name = "label" + str(x.id)
+                link = mywid.Link(x.name, label_name, 'focused-pr-data')
                 urwid.connect_signal(
                     link, 'selected',
                     lambda link, x=x: self.searchLabel(x.name))

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -20,6 +20,7 @@ try:
     import ordereddict
 except:
     pass
+import os
 import textwrap
 
 import urwid
@@ -57,10 +58,12 @@ class EditLabelsDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
         self.labels_checkboxes = []
 
         rows.append(urwid.Text(u"Labels:"))
+        truecolors = (os.environ.get('COLORTERM') == 'truecolor')
         for label in pr.repository.labels:
-            palette_item = "label_" + str(label.id)
             b = mywid.FixedCheckBox(label.name, state=(label in pr.labels))
-            b.set_label((palette_item, label.name))
+            if truecolors:
+                palette_item = "label_" + str(label.id)
+                b.set_label((palette_item, label.name))
             rows.append(b)
             self.labels_checkboxes.append(b)
         rows.append(urwid.Divider())


### PR DESCRIPTION
When the terminal supports it, use the original label color as a background to make them stand out and distinguish them more easily.

Fixes #86 