### PR TITLE
Skip approval when review is not tied to a commit

### DIFF
--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -784,7 +784,7 @@ class SyncPullRequestTask(Task):
                     message.body = (remote_review.get('body','') or '').replace('\r','')
 
                 review_state = remote_review.get('state')
-                if review_state:
+                if review_state and remote_review.get('commit_id'):
                     approval = session.getApproval(pr, account, remote_review.get('commit_id'))
                     own_approval = session.getApproval(pr, session.getOwnAccount(), remote_review.get('commit_id'))
 


### PR DESCRIPTION
There seems to be a recent change to the github API, where some reviews no longer have an associated commit sha. In that case, skip the approval to prevent a stack trace, and the PR being marked as outdated.

Fix #94