### PR TITLE
Remove pin on older mistune library

### DIFF
--- a/hubtty/markdown.py
+++ b/hubtty/markdown.py
@@ -28,7 +28,7 @@ class Renderer:
         for element in ast:
             match element['type']:
                 case 'text':
-                    text.append(element['text'])
+                    text.append(element.get('raw', ''))
                 case 'strong':
                     text.append(('md-strong', self.toUrwidMarkup(element['children'])))
                 case 'emphasis':
@@ -36,39 +36,44 @@ class Renderer:
                 case 'strikethrough':
                     text.append(('md-strikethrough', self.toUrwidMarkup(element['children'])))
                 case 'heading':
-                    text.append(('md-heading', ["#" * element['level'], " ", self.toUrwidMarkup(element['children']), "\n"]))
+                    level = element.get('attrs', {}).get('level', 1)
+                    text.append(('md-heading', ["#" * level, " ", self.toUrwidMarkup(element['children']), "\n"]))
                 case 'paragraph':
                     # Add newline before paragraphs if needed
                     if self.needsNewLine(text):
                         text.append("\n")
                     text.extend(self.toUrwidMarkup(element['children']))
                     text.append("\n")
-                case 'newline':
+                case 'newline' | 'blank_line' | 'softbreak' | 'linebeak':
                     text.append("\n")
                 case 'thematic_break':
                     text.append(('md-thematicbreak', "\n———————————————\n\n"))
                 case 'block_quote':
                     text.append(('md-blockquote', ["| ", self.toUrwidMarkup(element['children'])]))
                 case 'block_code':
-                    info = element['info']
-                    if info == None:
+                    info = element.get('attrs', {}).get('info', '')
+                    if info is None:
                         info = ""
-                    text.append(('md-blockcode', ["```%s\n" % info, element['text'], "```\n"]))
-                case 'image' | 'block_html':
-                    # image and HTML comments - do nothing
+                    raw_code = element.get('raw', '')
+                    text.append(('md-blockcode', ["```%s\n" % info, raw_code, "```\n"]))
+                case 'image' | 'block_html' | 'blank_line':
+                    # image, HTML comments, and blank lines - do nothing
                     pass
                 case 'codespan':
-                    text.append(('md-codespan', element['text']))
+                    text.append(('md-codespan', element.get('raw', '')))
                 case 'list':
-                    if element['ordered']:
+                    attrs = element.get('attrs', {})
+                    ordered = attrs.get('ordered', False)
+                    depth = attrs.get('depth', 0)
+                    if ordered:
                         idx = 1
                         for li in element['children']:
-                            text.append("  " * element['level'] + "%s. " % idx)
+                            text.append("  " * depth + "%s. " % idx)
                             text.extend(self.toUrwidMarkup([li]))
                             idx += 1
                     else:
                         for li in element['children']:
-                            text.append("  " * element['level'] + "- ")
+                            text.append("  " * depth + "- ")
                             text.extend(self.toUrwidMarkup([li]))
                 case 'list_item':
                     text.extend(self.toUrwidMarkup(element['children']))
@@ -76,11 +81,11 @@ class Renderer:
                     text.extend(self.toUrwidMarkup(element['children']))
                     text.append("\n")
                 case 'link':
-                    url = element['link']
+                    url = element.get('attrs', {}).get('url', '')
                     link_text = ""
                     for child in element['children']:
-                        if child.get('text'):
-                            link_text += child['text']
+                        if child.get('raw'):
+                            link_text += child['raw']
                         elif child.get('alt'):
                             link_text += child['alt']
                     link = mywid.Link(link_text, 'link', 'focused-link')
@@ -142,7 +147,7 @@ class Renderer:
         
 
     def render(self, text):
-        md = mistune.create_markdown(renderer=mistune.AstRenderer(), plugins=['strikethrough'])
+        md = mistune.create_markdown(renderer='ast', plugins=['strikethrough'])
         # Misture returns newline for empty text, we don't want that
         if not text:
             return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "voluptuous>=0.7",
     "ply>=3.4",
     "pyxdg",
-    "mistune>=2.0,<3.0.0",
+    "mistune>=3.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -231,11 +231,6 @@ dependencies = [
     { name = "voluptuous" },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "flake8" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "flake8" },
@@ -244,9 +239,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=0.6.4" },
-    { name = "flake8", marker = "extra == 'dev'" },
     { name = "gitpython", specifier = ">=0.3.7" },
-    { name = "mistune", specifier = ">=2.0,<3.0.0" },
+    { name = "mistune", specifier = ">=3.0" },
     { name = "ply", specifier = ">=3.4" },
     { name = "python-dateutil" },
     { name = "pyxdg" },
@@ -256,7 +250,6 @@ requires-dist = [
     { name = "urwid", specifier = ">=2.2.0" },
     { name = "voluptuous", specifier = ">=0.7" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "flake8", specifier = ">=7.3.0" }]
@@ -378,11 +371,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "2.0.5"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/6b/d8013058fcdb0088b4130164fc961e15c50d30302f60a349c16bdfda9770/mistune-2.0.5.tar.gz", hash = "sha256:0246113cb2492db875c6be56974a7c893333bf26cd92891c85f63151cee09d34", size = 75854, upload-time = "2023-02-07T05:42:06.739Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/02/a7fb8b21d4d55ac93cdcde9d3638da5dd0ebdd3a4fed76c7725e10b81cbe/mistune-3.1.4.tar.gz", hash = "sha256:b5a7f801d389f724ec702840c11d8fc48f2b33519102fc7ee739e8177b672164", size = 94588, upload-time = "2025-08-29T07:20:43.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/e5/780d22d19543f339aad583304f58002975b586757aa590cbe7bea5cc6f13/mistune-2.0.5-py2.py3-none-any.whl", hash = "sha256:bad7f5d431886fcbaf5f758118ecff70d31f75231b34024a1341120340a65ce8", size = 24549, upload-time = "2023-02-07T05:42:05.089Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl", hash = "sha256:93691da911e5d9d2e23bc54472892aff676df27a75274962ff9edc210364266d", size = 53481, upload-time = "2025-08-29T07:20:42.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update from mistune 2.x to 3.x for markdown rendering.

https://mistune.lepture.com/en/latest/upgrade.html#upgrade-from-v2-to-v3