### PR TITLE
Make rate limit handling more robust

### DIFF
--- a/hubtty/sync/exceptions.py
+++ b/hubtty/sync/exceptions.py
@@ -15,6 +15,8 @@
 
 """Exceptions for the sync module."""
 
+from typing import Optional
+
 
 class OfflineError(Exception):
     """Raised when the GitHub API is unreachable (e.g., 503 status)."""
@@ -27,5 +29,38 @@ class RestrictedError(Exception):
 
 
 class RateLimitError(Exception):
-    """Raised when GitHub API rate limit is hit."""
-    pass
+    """Raised when GitHub API rate limit is hit.
+
+    Attributes:
+        reset_time: Unix timestamp when the rate limit resets.
+        retry_after: Seconds to wait before retrying (from Retry-After header).
+        remaining: Number of requests remaining in the current quota.
+        is_secondary: Whether this is a secondary rate limit.
+        url: The URL that was rate limited.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        reset_time: Optional[int] = None,
+        retry_after: Optional[int] = None,
+        remaining: Optional[int] = None,
+        is_secondary: bool = False,
+        url: Optional[str] = None,
+    ):
+        """Initialize a RateLimitError.
+
+        Args:
+            message: Error message describing the rate limit.
+            reset_time: Unix timestamp when rate limit resets.
+            retry_after: Seconds to wait (from Retry-After header).
+            remaining: Requests remaining in current quota.
+            is_secondary: True if this is a secondary rate limit.
+            url: The URL that triggered the rate limit.
+        """
+        super().__init__(message)
+        self.reset_time = reset_time
+        self.retry_after = retry_after
+        self.remaining = remaining
+        self.is_secondary = is_secondary
+        self.url = url

--- a/hubtty/sync/http.py
+++ b/hubtty/sync/http.py
@@ -79,12 +79,27 @@ class HTTPClient:
         Raises:
             OfflineError: If the server returned 503.
             RestrictedError: If OAuth app restrictions block access.
+            RateLimitError: If rate limit is exceeded.
             Exception: For other 4xx/5xx status codes.
         """
         self.log.debug('HTTP status code: %d', response.status_code)
+
+        # Handle 429 (rate limit exceeded)
+        if response.status_code == 429:
+            self._handle_rate_limit_response(response)
+
+        # Handle 503 (service unavailable)
         if response.status_code == 503:
             raise OfflineError("Received 503 status code")
+
+        # Handle 403 (forbidden)
         elif response.status_code == 403:
+            # Check if it's a rate limit 403 first
+            remaining = response.headers.get('X-RateLimit-Remaining')
+            if remaining and int(remaining) == 0:
+                self._handle_rate_limit_response(response)
+
+            # Check for OAuth restriction
             result = re.search(
                 r"the `([\w-]+)` organization has enabled OAuth App access restrictions",
                 response.text
@@ -107,10 +122,134 @@ class HTTPClient:
                 raise Exception(
                     f"Received {response.status_code} status code: {response.text}"
                 )
+
+        # Other error codes
         elif response.status_code >= 400:
             raise Exception(
                 f"Received {response.status_code} status code: {response.text}"
             )
+
+    def _handle_rate_limit_response(self, response: requests.Response) -> None:
+        """Extract rate limit info and raise RateLimitError.
+
+        Args:
+            response: HTTP response with rate limit error.
+
+        Raises:
+            RateLimitError: Always raised with extracted rate limit context.
+        """
+        retry_after = response.headers.get('Retry-After')
+        reset_time = response.headers.get('X-RateLimit-Reset')
+        remaining = response.headers.get('X-RateLimit-Remaining')
+
+        # Convert to integers if present
+        retry_after_int = int(retry_after) if retry_after else None
+        reset_time_int = int(reset_time) if reset_time else None
+        remaining_int = int(remaining) if remaining else None
+
+        # Determine if this is a secondary rate limit
+        # Secondary: Has retry-after OR (remaining != 0)
+        is_secondary = bool(retry_after) or (
+            remaining_int is not None and remaining_int != 0
+        )
+
+        # Build informative error message
+        parts = [f"Rate limit exceeded (HTTP {response.status_code})"]
+        if retry_after_int:
+            parts.append(f"retry-after: {retry_after_int}s")
+        if reset_time_int:
+            parts.append(f"reset: {reset_time_int}")
+        if remaining_int is not None:
+            parts.append(f"remaining: {remaining_int}")
+
+        message = ", ".join(parts)
+
+        raise RateLimitError(
+            message,
+            reset_time=reset_time_int,
+            retry_after=retry_after_int,
+            remaining=remaining_int,
+            is_secondary=is_secondary,
+            url=response.url,
+        )
+
+    def _should_handle_rate_limit(self, response: requests.Response) -> bool:
+        """Check if response indicates rate limiting that should be handled.
+
+        Args:
+            response: HTTP response to check.
+
+        Returns:
+            True if we should wait and retry due to rate limiting.
+        """
+        # Case 1: Explicit rate limit response (429 or 403 with remaining=0)
+        if response.status_code in [403, 429]:
+            remaining_str = response.headers.get('X-RateLimit-Remaining')
+            if remaining_str and int(remaining_str) == 0:
+                return True
+            if response.status_code == 429:
+                return True
+
+        # Case 2: Proactive rate limit (success but no quota left)
+        if response.status_code == 200:
+            remaining_str = response.headers.get('X-RateLimit-Remaining', '1')
+            remaining = int(remaining_str)
+            if remaining < 1:
+                return True
+
+        return False
+
+    def _wait_for_rate_limit(self, response: requests.Response, url: str) -> None:
+        """Wait for rate limit to reset before retrying.
+
+        Follows GitHub's documented strategy:
+        1. Use retry-after header if present (secondary rate limits)
+        2. Use x-ratelimit-reset if present (primary rate limits)
+        3. Otherwise wait 60 seconds (secondary rate limit fallback)
+
+        Args:
+            response: HTTP response with rate limit information.
+            url: The URL being requested (for logging).
+        """
+        retry_after = response.headers.get('Retry-After')
+        reset_time = response.headers.get('X-RateLimit-Reset')
+        remaining = response.headers.get('X-RateLimit-Remaining', '?')
+
+        # Strategy 1: Use retry-after header (secondary rate limits)
+        if retry_after:
+            sleep_time = int(retry_after)
+            self.log.info(
+                'Hit secondary rate limit on %s, retry-after: %d seconds (remaining: %s)',
+                url,
+                sleep_time,
+                remaining,
+            )
+            time.sleep(sleep_time)
+            return
+
+        # Strategy 2: Use x-ratelimit-reset (primary rate limits)
+        if reset_time:
+            # Prevent negative sleep due to clock skew
+            sleep_time = max(1, int(reset_time) - int(time.time()))
+            self.log.info(
+                'Hit primary rate limit on %s, reset in: %d seconds (remaining: %s)',
+                url,
+                sleep_time,
+                remaining,
+            )
+            time.sleep(sleep_time)
+            return
+
+        # Strategy 3: Fallback for secondary rate limits without headers
+        # Per GitHub docs: "wait for at least one minute before retrying"
+        sleep_time = 60
+        self.log.info(
+            'Hit rate limit on %s with no timing headers, waiting %d seconds (remaining: %s)',
+            url,
+            sleep_time,
+            remaining,
+        )
+        time.sleep(sleep_time)
 
     def get(
         self,
@@ -149,17 +288,17 @@ class HTTPClient:
                 timeout=TIMEOUT,
                 headers={**default_headers, **(headers or {})}
             )
+
+            # CRITICAL: Check rate limits BEFORE calling response_callback
+            # This allows us to handle rate limit responses before they become exceptions
+            if self._should_handle_rate_limit(r):
+                self._wait_for_rate_limit(r, url)
+                continue  # Retry the request
+
+            # Now validate response (will raise exceptions for non-rate-limit errors)
             response_callback(r)
 
-            if int(r.headers.get('X-RateLimit-Remaining', 1)) < 1:
-                if r.headers.get('X-RateLimit-Reset'):
-                    sleep = int(r.headers.get('X-RateLimit-Reset')) - int(time.time())
-                    self.log.debug('Hit rate limit, retrying in %d seconds', sleep)
-                    time.sleep(sleep)
-                    continue
-                else:
-                    raise RateLimitError("Hitting RateLimit")
-
+            # Process successful response
             if r.status_code == 200:
                 result = json.loads(r.text)
                 # Search queries store results under the 'items' key
@@ -174,6 +313,7 @@ class HTTPClient:
                 else:
                     self.log.debug('200 OK, No body.')
 
+            # Check for pagination
             if 'next' in r.links.keys():
                 url = r.links['next']['url']
             else:
@@ -217,25 +357,42 @@ class HTTPClient:
         self.log.debug('%s: %s', method.upper(), url)
         self.log.debug('data: %s', data)
 
-        request_method = getattr(self.session, method)
-        r = request_method(
-            url,
-            data=json.dumps(data).encode('utf8'),
-            timeout=TIMEOUT,
-            headers={**default_headers, **(headers or {})}
-        )
-        response_callback(r)
-        self.log.debug('Received: %s', r.text)
+        # Retry loop for rate limiting (max 3 attempts)
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            request_method = getattr(self.session, method)
+            r = request_method(
+                url,
+                data=json.dumps(data).encode('utf8'),
+                timeout=TIMEOUT,
+                headers={**default_headers, **(headers or {})}
+            )
 
-        # Only POST returns parsed response
-        if method == 'post' and r.text and len(r.text) > 0:
-            try:
-                return json.loads(r.text)
-            except Exception:
-                self.log.exception(
-                    "Unable to parse result %s from post to %s", r.text, url
-                )
-                raise
+            # Check rate limits before validation
+            if self._should_handle_rate_limit(r):
+                if attempt < max_attempts - 1:
+                    self._wait_for_rate_limit(r, url)
+                    continue  # Retry
+                else:
+                    # Last attempt, let it raise
+                    response_callback(r)
+
+            # Validate response
+            response_callback(r)
+            self.log.debug('Received: %s', r.text)
+
+            # Only POST returns parsed response
+            if method == 'post' and r.text and len(r.text) > 0:
+                try:
+                    return json.loads(r.text)
+                except Exception:
+                    self.log.exception(
+                        "Unable to parse result %s from post to %s", r.text, url
+                    )
+                    raise
+            return None
+
+        # Should never reach here
         return None
 
     def post(

--- a/hubtty/sync/sync.py
+++ b/hubtty/sync/sync.py
@@ -72,6 +72,7 @@ class Sync(HTTPClient):
         super().__init__(app, user_agent, github_api_version)
 
         self.offline = False
+        self.consecutive_rate_limit_errors = 0
         self.account_id: Optional[int] = None
         self.queue = MultiQueue([HIGH_PRIORITY, NORMAL_PRIORITY, LOW_PRIORITY])
         self.result_queue: queue.Queue = queue.Queue()
@@ -164,12 +165,19 @@ class Sync(HTTPClient):
             requests.exceptions.ReadTimeout,
         ) as e:
             self.log.warning("Offline due to: %s", e)
+
+            # Calculate backoff time
+            if isinstance(e, RateLimitError):
+                backoff = self._calculate_rate_limit_backoff(e)
+            else:
+                backoff = 30  # Fixed backoff for non-rate-limit errors
+
             if not self.offline:
                 self.submitTask(UploadReviewsTask(priority=HIGH_PRIORITY))
             self.offline = True
             self.app.status.update(offline=True, refresh=False)
             os.write(pipe, b'refresh\n')
-            time.sleep(30)
+            time.sleep(backoff)
             return task
         except RestrictedError as e:
             task.complete(False)
@@ -182,11 +190,75 @@ class Sync(HTTPClient):
             self.log.exception('Exception running task %s', task)
             self.app.status.update(error=True, refresh=False)
         self.offline = False
+        self.consecutive_rate_limit_errors = 0
         self.app.status.update(offline=False, refresh=False)
         for r in task.results:
             self.result_queue.put(r)
         os.write(pipe, b'refresh\n')
         return None
+
+    def _calculate_rate_limit_backoff(self, error: RateLimitError) -> int:
+        """Calculate backoff time for rate limit errors.
+
+        For primary rate limits: Use the timing from the error
+        For secondary rate limits: Use exponential backoff
+
+        Per GitHub docs:
+        - If retry-after present: use it
+        - If x-ratelimit-reset present: use it
+        - Otherwise: wait 1 min, then exponentially increase
+
+        Args:
+            error: RateLimitError with timing information.
+
+        Returns:
+            Number of seconds to wait before retrying.
+
+        Raises:
+            RateLimitError: If max retries (5) exceeded for secondary rate limits.
+        """
+        # Primary rate limits: Use exact timing from headers
+        if not error.is_secondary:
+            if error.retry_after:
+                return error.retry_after
+            if error.reset_time:
+                return max(1, error.reset_time - int(time.time()))
+            # Shouldn't happen for primary, but fallback to 60s
+            return 60
+
+        # Secondary rate limits: Exponential backoff
+        self.consecutive_rate_limit_errors += 1
+
+        # If we have timing info from headers, use it for first attempt
+        if self.consecutive_rate_limit_errors == 1:
+            if error.retry_after:
+                self.log.info(
+                    'Secondary rate limit (attempt 1), using retry-after: %ds',
+                    error.retry_after,
+                )
+                return error.retry_after
+            # GitHub says "wait at least one minute"
+            self.log.info('Secondary rate limit (attempt 1), waiting 60s')
+            return 60
+
+        # Subsequent attempts: Exponential backoff
+        # 60s, 120s, 240s, 480s, max 600s (10 min)
+        backoff = min(60 * (2 ** (self.consecutive_rate_limit_errors - 1)), 600)
+
+        self.log.info(
+            'Secondary rate limit (attempt %d), exponential backoff: %ds',
+            self.consecutive_rate_limit_errors,
+            backoff,
+        )
+
+        # Give up after 5 attempts
+        if self.consecutive_rate_limit_errors >= 5:
+            self.log.error('Hit secondary rate limit 5 times, giving up on task')
+            # Reset counter and raise to fail the task
+            self.consecutive_rate_limit_errors = 0
+            raise error
+
+        return backoff
 
     def syncSubscribedRepositories(self) -> None:
         """Sync all subscribed repositories and wait for completion."""

--- a/tests/sync/test_http.py
+++ b/tests/sync/test_http.py
@@ -90,6 +90,7 @@ class TestCheckResponse:
         response = Mock()
         response.status_code = 403
         response.text = "the `myorg` organization has enabled OAuth App access restrictions"
+        response.headers = {'X-RateLimit-Remaining': '100'}  # Not rate limited
 
         with pytest.raises(RestrictedError) as exc_info:
             http_client.checkResponse(response)
@@ -100,6 +101,7 @@ class TestCheckResponse:
         response = Mock()
         response.status_code = 403
         response.text = "the `testorg` organization has enabled OAuth App access restrictions"
+        response.headers = {'X-RateLimit-Remaining': '100'}  # Not rate limited
 
         with pytest.raises(RestrictedError):
             http_client.checkResponse(response)
@@ -113,6 +115,7 @@ class TestCheckResponse:
         response = Mock()
         response.status_code = 403
         response.text = "Forbidden"
+        response.headers = {'X-RateLimit-Remaining': '100'}  # Not rate limited
 
         with pytest.raises(Exception) as exc_info:
             http_client.checkResponse(response)
@@ -232,17 +235,218 @@ class TestHTTPGet:
 
         mock_sleep.assert_called_once()
 
-    def test_get_rate_limit_no_reset_raises(self, http_client):
-        """GET raises RateLimitError when rate limited without reset."""
-        response = Mock()
-        response.status_code = 200
-        response.text = '{"id": 1}'
-        response.headers = {'X-RateLimit-Remaining': '0'}
-        response.links = {}
+    def test_get_rate_limit_no_reset_waits_60s(self, http_client):
+        """GET waits 60s when rate limited without reset time (secondary rate limit fallback)."""
+        # First response: rate limited with no reset time
+        r1 = Mock()
+        r1.status_code = 200
+        r1.text = '{"id": 1}'
+        r1.headers = {'X-RateLimit-Remaining': '0'}
+        r1.links = {}
 
-        with patch.object(http_client.session, 'get', return_value=response):
-            with pytest.raises(RateLimitError):
+        # Second response: success after waiting
+        r2 = Mock()
+        r2.status_code = 200
+        r2.text = '{"id": 1}'
+        r2.headers = {'X-RateLimit-Remaining': '100'}
+        r2.links = {}
+
+        with patch.object(http_client.session, 'get', side_effect=[r1, r2]):
+            with patch('hubtty.sync.http.time.sleep') as mock_sleep:
                 http_client.get('repos/test')
+
+        # Should sleep for 60 seconds (GitHub's recommended minimum)
+        mock_sleep.assert_called_once_with(60)
+
+    def test_get_handles_429_with_retry_after(self, http_client):
+        """GET handles 429 with Retry-After header."""
+        # First response: 429 with retry-after
+        r1 = Mock()
+        r1.status_code = 429
+        r1.text = '{"message": "API rate limit exceeded"}'
+        r1.headers = {'Retry-After': '30', 'X-RateLimit-Remaining': '0'}
+        r1.links = {}
+        r1.url = 'https://api.github.com/repos/test'
+
+        # Second response: success
+        r2 = Mock()
+        r2.status_code = 200
+        r2.text = '{"id": 1}'
+        r2.headers = {'X-RateLimit-Remaining': '100'}
+        r2.links = {}
+
+        with patch.object(http_client.session, 'get', side_effect=[r1, r2]):
+            with patch('hubtty.sync.http.time.sleep') as mock_sleep:
+                result = http_client.get('repos/test')
+
+        # Should use retry-after value
+        mock_sleep.assert_called_once_with(30)
+        assert result == {"id": 1}
+
+    def test_get_handles_429_with_reset_time(self, http_client):
+        """GET handles 429 with X-RateLimit-Reset header."""
+        import time
+
+        reset_time = int(time.time()) + 45
+
+        # First response: 429 with reset time
+        r1 = Mock()
+        r1.status_code = 429
+        r1.text = '{"message": "API rate limit exceeded"}'
+        r1.headers = {
+            'X-RateLimit-Reset': str(reset_time),
+            'X-RateLimit-Remaining': '0',
+        }
+        r1.links = {}
+        r1.url = 'https://api.github.com/repos/test'
+
+        # Second response: success
+        r2 = Mock()
+        r2.status_code = 200
+        r2.text = '{"id": 1}'
+        r2.headers = {'X-RateLimit-Remaining': '100'}
+        r2.links = {}
+
+        with patch.object(http_client.session, 'get', side_effect=[r1, r2]):
+            with patch('hubtty.sync.http.time.sleep') as mock_sleep:
+                with patch('hubtty.sync.http.time.time', return_value=time.time()):
+                    result = http_client.get('repos/test')
+
+        # Should sleep until reset time (at least 1 second due to max())
+        assert mock_sleep.called
+        sleep_duration = mock_sleep.call_args[0][0]
+        assert sleep_duration >= 1
+        assert result == {"id": 1}
+
+    def test_get_handles_403_rate_limit(self, http_client):
+        """GET handles 403 with X-RateLimit-Remaining: 0 as rate limit."""
+        import time
+
+        reset_time = int(time.time()) + 30
+
+        # First response: 403 with rate limit headers
+        r1 = Mock()
+        r1.status_code = 403
+        r1.text = '{"message": "API rate limit exceeded"}'
+        r1.headers = {
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': str(reset_time),
+        }
+        r1.links = {}
+        r1.url = 'https://api.github.com/repos/test'
+
+        # Second response: success
+        r2 = Mock()
+        r2.status_code = 200
+        r2.text = '{"id": 1}'
+        r2.headers = {'X-RateLimit-Remaining': '100'}
+        r2.links = {}
+
+        with patch.object(http_client.session, 'get', side_effect=[r1, r2]):
+            with patch('hubtty.sync.http.time.sleep') as mock_sleep:
+                result = http_client.get('repos/test')
+
+        # Should handle as rate limit, not OAuth restriction
+        assert mock_sleep.called
+        assert result == {"id": 1}
+
+    def test_get_secondary_rate_limit_without_headers(self, http_client):
+        """GET handles secondary rate limit with no timing headers."""
+        # First response: 429 with no timing headers
+        r1 = Mock()
+        r1.status_code = 429
+        r1.text = '{"message": "You have exceeded a secondary rate limit"}'
+        r1.headers = {}
+        r1.links = {}
+        r1.url = 'https://api.github.com/repos/test'
+
+        # Second response: success
+        r2 = Mock()
+        r2.status_code = 200
+        r2.text = '{"id": 1}'
+        r2.headers = {'X-RateLimit-Remaining': '100'}
+        r2.links = {}
+
+        with patch.object(http_client.session, 'get', side_effect=[r1, r2]):
+            with patch('hubtty.sync.http.time.sleep') as mock_sleep:
+                result = http_client.get('repos/test')
+
+        # Should wait 60 seconds (GitHub's minimum for secondary limits)
+        mock_sleep.assert_called_once_with(60)
+        assert result == {"id": 1}
+
+    def test_checkResponse_handles_429(self, http_client):
+        """checkResponse raises RateLimitError with attributes for 429."""
+        response = Mock()
+        response.status_code = 429
+        response.text = '{"message": "API rate limit exceeded"}'
+        response.headers = {
+            'Retry-After': '45',
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': '1234567890',
+        }
+        response.url = 'https://api.github.com/repos/test'
+
+        with pytest.raises(RateLimitError) as exc_info:
+            http_client.checkResponse(response)
+
+        error = exc_info.value
+        assert error.retry_after == 45
+        assert error.reset_time == 1234567890
+        assert error.remaining == 0
+        assert error.url == 'https://api.github.com/repos/test'
+        assert error.is_secondary  # Has retry-after, so it's secondary
+
+    def test_rate_limit_error_attributes(self):
+        """RateLimitError stores all context correctly."""
+        error = RateLimitError(
+            'Test rate limit',
+            reset_time=1234567890,
+            retry_after=60,
+            remaining=0,
+            is_secondary=True,
+            url='https://api.github.com/test',
+        )
+
+        assert str(error) == 'Test rate limit'
+        assert error.reset_time == 1234567890
+        assert error.retry_after == 60
+        assert error.remaining == 0
+        assert error.is_secondary is True
+        assert error.url == 'https://api.github.com/test'
+
+    def test_negative_sleep_prevention(self, http_client):
+        """GET prevents negative sleep from clock skew."""
+        import time
+
+        # Reset time in the past (clock skew scenario)
+        reset_time = int(time.time()) - 10
+
+        # First response: rate limited with reset time in past
+        r1 = Mock()
+        r1.status_code = 200
+        r1.text = '{"id": 1}'
+        r1.headers = {
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': str(reset_time),
+        }
+        r1.links = {}
+
+        # Second response: success
+        r2 = Mock()
+        r2.status_code = 200
+        r2.text = '{"id": 1}'
+        r2.headers = {'X-RateLimit-Remaining': '100'}
+        r2.links = {}
+
+        with patch.object(http_client.session, 'get', side_effect=[r1, r2]):
+            with patch('hubtty.sync.http.time.sleep') as mock_sleep:
+                http_client.get('repos/test')
+
+        # Should sleep for at least 1 second (not negative)
+        assert mock_sleep.called
+        sleep_duration = mock_sleep.call_args[0][0]
+        assert sleep_duration >= 1
 
 
 class TestHTTPPost:
@@ -285,6 +489,54 @@ class TestHTTPPost:
 
         assert result is None
 
+    def test_post_handles_rate_limit_with_retry(self, http_client):
+        """POST retries when rate limited."""
+        import time
+
+        reset_time = int(time.time()) + 30
+
+        # First response: rate limited
+        r1 = Mock()
+        r1.status_code = 429
+        r1.text = '{"message": "API rate limit exceeded"}'
+        r1.headers = {
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': str(reset_time),
+        }
+        r1.url = 'https://api.github.com/repos/test'
+
+        # Second response: success
+        r2 = Mock()
+        r2.status_code = 201
+        r2.text = '{"id": 123}'
+        r2.headers = {'X-RateLimit-Remaining': '100'}
+
+        with patch.object(http_client.session, 'post', side_effect=[r1, r2]):
+            with patch('hubtty.sync.http.time.sleep') as mock_sleep:
+                result = http_client.post('repos/test', {'key': 'value'})
+
+        # Should have slept and retried
+        assert mock_sleep.called
+        assert result == {"id": 123}
+
+    def test_post_rate_limit_max_retries(self, http_client):
+        """POST gives up after max retries on rate limit."""
+        import time
+
+        reset_time = int(time.time()) + 30
+
+        # All responses: rate limited
+        r = Mock()
+        r.status_code = 429
+        r.text = '{"message": "API rate limit exceeded"}'
+        r.headers = {'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': str(reset_time)}
+        r.url = 'https://api.github.com/repos/test'
+
+        with patch.object(http_client.session, 'post', return_value=r):
+            with patch('hubtty.sync.http.time.sleep'):
+                with pytest.raises(RateLimitError):
+                    http_client.post('repos/test', {'key': 'value'})
+
 
 class TestHTTPPut:
     """Tests for PUT requests."""
@@ -294,6 +546,7 @@ class TestHTTPPut:
         response = Mock()
         response.status_code = 200
         response.text = ''
+        response.headers = {'X-RateLimit-Remaining': '100'}
 
         with patch.object(http_client.session, 'put', return_value=response) as mock_put:
             http_client.put('repos/test', {'key': 'value'})
@@ -307,6 +560,7 @@ class TestHTTPPut:
         response = Mock()
         response.status_code = 200
         response.text = '{"ignored": true}'
+        response.headers = {'X-RateLimit-Remaining': '100'}
 
         with patch.object(http_client.session, 'put', return_value=response):
             result = http_client.put('repos/test', {})
@@ -322,6 +576,7 @@ class TestHTTPPatch:
         response = Mock()
         response.status_code = 200
         response.text = ''
+        response.headers = {'X-RateLimit-Remaining': '100'}
 
         with patch.object(http_client.session, 'patch', return_value=response) as mock_patch:
             http_client.patch('repos/test', {'key': 'value'})
@@ -339,6 +594,7 @@ class TestHTTPDelete:
         response = Mock()
         response.status_code = 200
         response.text = ''
+        response.headers = {'X-RateLimit-Remaining': '100'}
 
         with patch.object(http_client.session, 'delete', return_value=response) as mock_delete:
             http_client.delete('repos/test', {'key': 'value'})

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -1,0 +1,170 @@
+# Copyright 2014 OpenStack Foundation
+# Copyright 2014 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Tests for Sync class."""
+
+import pytest
+import time
+from unittest.mock import Mock, patch
+
+from hubtty.sync.sync import Sync
+from hubtty.sync.exceptions import RateLimitError
+
+
+@pytest.fixture
+def mock_app():
+    """Create a mock App instance."""
+    app = Mock()
+    app.config.api_url = "https://api.github.com/"
+    app.config.token = "test-token"
+    app.config.expire_age = "2 months"
+    app.error = Mock()
+    app.db.getSession = Mock()
+    app.status.update = Mock()
+    return app
+
+
+@pytest.fixture
+def sync_instance(mock_app):
+    """Create a Sync instance for testing."""
+    with patch("hubtty.sync.sync.threading"):
+        sync = Sync(mock_app, disable_background_sync=True)
+    return sync
+
+
+class TestRateLimitBackoff:
+    """Tests for rate limit backoff calculation."""
+
+    def test_primary_rate_limit_uses_retry_after(self, sync_instance):
+        """Primary rate limit uses retry-after from headers."""
+        error = RateLimitError("Rate limited", retry_after=45, is_secondary=False)
+
+        backoff = sync_instance._calculate_rate_limit_backoff(error)
+
+        assert backoff == 45
+        assert sync_instance.consecutive_rate_limit_errors == 0
+
+    def test_primary_rate_limit_uses_reset_time(self, sync_instance):
+        """Primary rate limit uses reset time when retry-after absent."""
+        reset_time = int(time.time()) + 30
+        error = RateLimitError(
+            "Rate limited", reset_time=reset_time, is_secondary=False
+        )
+
+        backoff = sync_instance._calculate_rate_limit_backoff(error)
+
+        # Should be at least 1 second (due to max(1, ...))
+        assert backoff >= 1
+        assert backoff <= 31  # Allow for slight time passage
+        assert sync_instance.consecutive_rate_limit_errors == 0
+
+    def test_primary_rate_limit_fallback_60s(self, sync_instance):
+        """Primary rate limit falls back to 60s when no headers."""
+        error = RateLimitError("Rate limited", is_secondary=False)
+
+        backoff = sync_instance._calculate_rate_limit_backoff(error)
+
+        assert backoff == 60
+        assert sync_instance.consecutive_rate_limit_errors == 0
+
+    def test_secondary_rate_limit_first_attempt_with_retry_after(self, sync_instance):
+        """Secondary rate limit first attempt uses retry-after."""
+        error = RateLimitError("Rate limited", retry_after=45, is_secondary=True)
+
+        backoff = sync_instance._calculate_rate_limit_backoff(error)
+
+        assert backoff == 45
+        assert sync_instance.consecutive_rate_limit_errors == 1
+
+    def test_secondary_rate_limit_first_attempt_without_headers(self, sync_instance):
+        """Secondary rate limit first attempt waits 60s without headers."""
+        error = RateLimitError("Rate limited", is_secondary=True)
+
+        backoff = sync_instance._calculate_rate_limit_backoff(error)
+
+        assert backoff == 60
+        assert sync_instance.consecutive_rate_limit_errors == 1
+
+    def test_secondary_rate_limit_exponential_backoff_progression(self, sync_instance):
+        """Secondary rate limit uses exponential backoff on repeated failures."""
+        error = RateLimitError("Rate limited", is_secondary=True)
+
+        # Attempt 1: 60s
+        backoff1 = sync_instance._calculate_rate_limit_backoff(error)
+        assert backoff1 == 60
+        assert sync_instance.consecutive_rate_limit_errors == 1
+
+        # Attempt 2: 120s (60 * 2^1)
+        backoff2 = sync_instance._calculate_rate_limit_backoff(error)
+        assert backoff2 == 120
+        assert sync_instance.consecutive_rate_limit_errors == 2
+
+        # Attempt 3: 240s (60 * 2^2)
+        backoff3 = sync_instance._calculate_rate_limit_backoff(error)
+        assert backoff3 == 240
+        assert sync_instance.consecutive_rate_limit_errors == 3
+
+        # Attempt 4: 480s (60 * 2^3)
+        backoff4 = sync_instance._calculate_rate_limit_backoff(error)
+        assert backoff4 == 480
+        assert sync_instance.consecutive_rate_limit_errors == 4
+
+    def test_secondary_rate_limit_max_backoff_600s(self, sync_instance):
+        """Secondary rate limit backoff capped at 600s (10 minutes)."""
+        error = RateLimitError("Rate limited", is_secondary=True)
+
+        # Test attempt 4: Should be 480s (60 * 2^3)
+        sync_instance.consecutive_rate_limit_errors = 3
+        backoff = sync_instance._calculate_rate_limit_backoff(error)
+        assert backoff == 480  # 60 * 2^3
+        assert sync_instance.consecutive_rate_limit_errors == 4
+
+        # Note: We can't test higher attempts because >= 5 raises.
+        # The cap of 600s is a safety measure for the formula
+        # but in practice we give up after attempt 5.
+        # The cap would only apply if the counter somehow got corrupted
+        # or if we change the max attempts in the future.
+
+    def test_secondary_rate_limit_gives_up_after_5_attempts(self, sync_instance):
+        """Secondary rate limit raises after 5 attempts."""
+        error = RateLimitError("Rate limited", is_secondary=True)
+
+        # Set to 4 attempts already
+        sync_instance.consecutive_rate_limit_errors = 4
+
+        # 5th attempt should raise
+        with pytest.raises(RateLimitError):
+            sync_instance._calculate_rate_limit_backoff(error)
+
+        # Counter should be reset
+        assert sync_instance.consecutive_rate_limit_errors == 0
+
+    def test_consecutive_errors_reset_on_success(self, sync_instance):
+        """Consecutive error counter resets after successful request."""
+        error = RateLimitError("Rate limited", is_secondary=True)
+
+        # Simulate some failures
+        sync_instance._calculate_rate_limit_backoff(error)
+        sync_instance._calculate_rate_limit_backoff(error)
+        assert sync_instance.consecutive_rate_limit_errors == 2
+
+        # Simulate a successful task completion (this happens in run() method)
+        # The counter gets reset in the success path of run()
+        sync_instance.consecutive_rate_limit_errors = 0
+
+        # Next failure should start fresh at attempt 1
+        backoff = sync_instance._calculate_rate_limit_backoff(error)
+        assert backoff == 60  # Back to first attempt
+        assert sync_instance.consecutive_rate_limit_errors == 1


### PR DESCRIPTION
The old rate limit strategy was broken: in get(), if X-RateLimit-Remaining hit 0 but X-RateLimit-Reset was missing, it raised RateLimitError and gave up. It also didn't handle HTTP 429 at all, and mutating requests (POST/PUT/PATCH/DELETE) had no rate limit handling whatsoever.