### PR TITLE
Add ETag / conditional request support to HTTP client

### DIFF
--- a/hubtty/sync/http.py
+++ b/hubtty/sync/http.py
@@ -51,6 +51,8 @@ class HTTPClient:
         self.session = requests.Session()
         self.session.headers.update({'Authorization': 'token ' + app.config.token})
         self.log = logging.getLogger('hubtty.sync')
+        # ETag cache: path -> (etag_value, cached_response)
+        self._etag_cache: Dict[str, tuple] = {}
 
     def url(self, path: str) -> str:
         """Convert a path to a full URL.
@@ -256,13 +258,24 @@ class HTTPClient:
         path: str,
         headers: Optional[Dict[str, str]] = None,
         response_callback: Optional[Callable[[requests.Response], None]] = None,
+        use_etag: bool = False,
     ) -> Any:
         """Perform a GET request with automatic pagination.
+
+        When *use_etag* is ``True`` the client will:
+
+        * Send ``If-None-Match`` with the cached ETag (if any) on the
+          first page request.
+        * On ``304 Not Modified`` return the previously-cached full
+          response — this costs **zero** against the GitHub rate limit.
+        * On ``200 OK`` store the new ETag and full (assembled) response
+          in an in-memory cache for subsequent conditional requests.
 
         Args:
             path: API path to request.
             headers: Additional headers to include.
             response_callback: Custom response validator (defaults to checkResponse).
+            use_etag: Enable conditional requests via ETag / If-None-Match.
 
         Returns:
             Parsed JSON response, or list of results if paginated.
@@ -270,6 +283,8 @@ class HTTPClient:
         url = self.url(path)
         ret = None
         done = False
+        is_first_page = True
+        first_page_etag = None
 
         default_headers = {
             **self._base_headers(),
@@ -280,13 +295,21 @@ class HTTPClient:
         if not response_callback:
             response_callback = self.checkResponse
 
+        # Build per-page extra headers.  On the first page we may
+        # include If-None-Match; subsequent pages never do.
+        extra = dict(headers or {})
+        cached_data = None
+        if use_etag and path in self._etag_cache:
+            cached_etag, cached_data = self._etag_cache[path]
+            extra['If-None-Match'] = cached_etag
+
         while not done:
             self.log.debug('GET: %s', url)
 
             r = self.session.get(
                 url,
                 timeout=TIMEOUT,
-                headers={**default_headers, **(headers or {})}
+                headers={**default_headers, **extra},
             )
 
             # CRITICAL: Check rate limits BEFORE calling response_callback
@@ -294,6 +317,12 @@ class HTTPClient:
             if self._should_handle_rate_limit(r):
                 self._wait_for_rate_limit(r, url)
                 continue  # Retry the request
+
+            # Handle 304 Not Modified — return cached data immediately.
+            # 304 responses don't count against the GitHub rate limit.
+            if use_etag and r.status_code == 304 and is_first_page:
+                self.log.debug('304 Not Modified (ETag cache hit): %s', path)
+                return cached_data
 
             # Now validate response (will raise exceptions for non-rate-limit errors)
             response_callback(r)
@@ -313,11 +342,25 @@ class HTTPClient:
                 else:
                     self.log.debug('200 OK, No body.')
 
+                # Capture ETag from first page
+                if use_etag and is_first_page:
+                    first_page_etag = r.headers.get('ETag')
+
+            # After the first page, strip If-None-Match so that
+            # subsequent pages are unconditional fetches.
+            if is_first_page:
+                is_first_page = False
+                extra = dict(headers or {})
+
             # Check for pagination
             if 'next' in r.links.keys():
                 url = r.links['next']['url']
             else:
                 done = True
+
+        # Store the fully-assembled result in the ETag cache.
+        if use_etag and first_page_etag is not None:
+            self._etag_cache[path] = (first_page_etag, ret)
 
         return ret
 

--- a/hubtty/sync/tasks/pull_request.py
+++ b/hubtty/sync/tasks/pull_request.py
@@ -191,13 +191,17 @@ class SyncPullRequestTask(Task):
 
         app = sync.app
         remote_pr = sync.get(f'repos/{self.pr_id}')
-        remote_commits = sync.get(f'repos/{self.pr_id}/commits?per_page=100')
+        remote_commits = sync.get(f'repos/{self.pr_id}/commits?per_page=100',
+                                   use_etag=True)
         # Limit to 50, as github seems to struggle sending more comments
         # https://github.com/hubtty/hubtty/issues/59
-        remote_pr_comments = sync.get(f'repos/{self.pr_id}/comments?per_page=50')
-        remote_pr_reviews = sync.get(f'repos/{self.pr_id}/reviews?per_page=100')
+        remote_pr_comments = sync.get(f'repos/{self.pr_id}/comments?per_page=50',
+                                      use_etag=True)
+        remote_pr_reviews = sync.get(f'repos/{self.pr_id}/reviews?per_page=100',
+                                     use_etag=True)
         remote_issue_comments = sync.get(
-            f'repos/{self.pr_id}/comments?per_page=100'.replace('/pulls/', '/issues/')
+            f'repos/{self.pr_id}/comments?per_page=100'.replace('/pulls/', '/issues/'),
+            use_etag=True,
         )
 
         repository_name = remote_pr['base']['repo']['full_name']
@@ -205,7 +209,8 @@ class SyncPullRequestTask(Task):
         # Get commit details
         for commit in remote_commits:
             remote_commit_details = sync.get(
-                f'repos/{repository_name}/commits/{commit["sha"]}'
+                f'repos/{repository_name}/commits/{commit["sha"]}',
+                use_etag=True,
             )
             commit['_hubtty_remote_commit_details'] = remote_commit_details
 

--- a/hubtty/sync/tasks/repository.py
+++ b/hubtty/sync/tasks/repository.py
@@ -115,7 +115,8 @@ class SyncRepositoryBranchesTask(Task):
             sync: The Sync instance to use for API calls.
         """
         app = sync.app
-        remote = sync.get(f'repos/{self.repository_name}/branches?per_page=100')
+        remote = sync.get(f'repos/{self.repository_name}/branches?per_page=100',
+                         use_etag=True)
         remote_branches = set()
         for b in remote:
             remote_branches.add(b['name'])
@@ -171,7 +172,8 @@ class SyncRepositoryLabelsTask(Task):
             sync: The Sync instance to use for API calls.
         """
         app = sync.app
-        remote_labels = sync.get(f'repos/{self.repository_name}/labels')
+        remote_labels = sync.get(f'repos/{self.repository_name}/labels',
+                                   use_etag=True)
         with app.db.getSession() as session:
             repository = session.getRepositoryByName(self.repository_name)
 

--- a/tests/sync/test_http.py
+++ b/tests/sync/test_http.py
@@ -616,3 +616,249 @@ class TestQuery:
         call_arg = mock_get.call_args[0][0]
         assert 'search/issues' in call_arg
         assert 'type:pr' in call_arg
+
+
+class TestETagSupport:
+    """Tests for ETag / conditional request support."""
+
+    def test_etag_disabled_by_default(self, http_client):
+        """use_etag defaults to False; no If-None-Match header."""
+        response = Mock()
+        response.status_code = 200
+        response.text = '{"id": 1}'
+        response.headers = {'X-RateLimit-Remaining': '100'}
+        response.links = {}
+
+        with patch.object(http_client.session, 'get',
+                          return_value=response) as mock_get:
+            http_client.get('repos/test')
+
+        sent_headers = mock_get.call_args.kwargs['headers']
+        assert 'If-None-Match' not in sent_headers
+
+    def test_etag_first_request_no_cache(self, http_client):
+        """First request with use_etag=True has no If-None-Match."""
+        response = Mock()
+        response.status_code = 200
+        response.text = '{"id": 1}'
+        response.headers = {
+            'X-RateLimit-Remaining': '100',
+            'ETag': '"abc123"',
+        }
+        response.links = {}
+
+        with patch.object(http_client.session, 'get',
+                          return_value=response) as mock_get:
+            result = http_client.get('repos/test', use_etag=True)
+
+        sent_headers = mock_get.call_args.kwargs['headers']
+        assert 'If-None-Match' not in sent_headers
+        assert result == {"id": 1}
+
+    def test_etag_cached_after_first_request(self, http_client):
+        """ETag and response are cached after a 200 with use_etag."""
+        response = Mock()
+        response.status_code = 200
+        response.text = '{"id": 1}'
+        response.headers = {
+            'X-RateLimit-Remaining': '100',
+            'ETag': '"abc123"',
+        }
+        response.links = {}
+
+        with patch.object(http_client.session, 'get',
+                          return_value=response):
+            http_client.get('repos/test', use_etag=True)
+
+        assert 'repos/test' in http_client._etag_cache
+        etag, cached = http_client._etag_cache['repos/test']
+        assert etag == '"abc123"'
+        assert cached == {"id": 1}
+
+    def test_etag_304_returns_cached_data(self, http_client):
+        """304 Not Modified returns previously cached data."""
+        # Seed the cache
+        http_client._etag_cache['repos/test'] = (
+            '"abc123"', {"id": 1, "cached": True}
+        )
+
+        response = Mock()
+        response.status_code = 304
+        response.headers = {'X-RateLimit-Remaining': '100'}
+        response.links = {}
+
+        with patch.object(http_client.session, 'get',
+                          return_value=response) as mock_get:
+            result = http_client.get('repos/test', use_etag=True)
+
+        assert result == {"id": 1, "cached": True}
+        # Verify If-None-Match was sent
+        sent_headers = mock_get.call_args.kwargs['headers']
+        assert sent_headers['If-None-Match'] == '"abc123"'
+
+    def test_etag_200_updates_cache(self, http_client):
+        """200 after a cached ETag updates the cache."""
+        # Seed the cache with old data
+        http_client._etag_cache['repos/test'] = (
+            '"old-etag"', {"id": 1}
+        )
+
+        response = Mock()
+        response.status_code = 200
+        response.text = '{"id": 2, "updated": true}'
+        response.headers = {
+            'X-RateLimit-Remaining': '100',
+            'ETag': '"new-etag"',
+        }
+        response.links = {}
+
+        with patch.object(http_client.session, 'get',
+                          return_value=response):
+            result = http_client.get('repos/test', use_etag=True)
+
+        assert result == {"id": 2, "updated": True}
+        etag, cached = http_client._etag_cache['repos/test']
+        assert etag == '"new-etag"'
+        assert cached == {"id": 2, "updated": True}
+
+    def test_etag_not_sent_when_disabled(self, http_client):
+        """If-None-Match not sent when use_etag=False even with cache."""
+        http_client._etag_cache['repos/test'] = (
+            '"abc123"', {"id": 1}
+        )
+
+        response = Mock()
+        response.status_code = 200
+        response.text = '{"id": 2}'
+        response.headers = {'X-RateLimit-Remaining': '100'}
+        response.links = {}
+
+        with patch.object(http_client.session, 'get',
+                          return_value=response) as mock_get:
+            result = http_client.get('repos/test', use_etag=False)
+
+        sent_headers = mock_get.call_args.kwargs['headers']
+        assert 'If-None-Match' not in sent_headers
+        assert result == {"id": 2}
+
+    def test_etag_pagination_caches_full_result(self, http_client):
+        """ETag from first page caches the full paginated result."""
+        r1 = Mock()
+        r1.status_code = 200
+        r1.text = '[{"id": 1}]'
+        r1.headers = {
+            'X-RateLimit-Remaining': '100',
+            'ETag': '"page1-etag"',
+        }
+        r1.links = {'next': {'url': 'https://api.github.com/page2'}}
+
+        r2 = Mock()
+        r2.status_code = 200
+        r2.text = '[{"id": 2}]'
+        r2.headers = {'X-RateLimit-Remaining': '99'}
+        r2.links = {}
+
+        with patch.object(http_client.session, 'get', side_effect=[r1, r2]):
+            result = http_client.get('repos/test', use_etag=True)
+
+        assert result == [{"id": 1}, {"id": 2}]
+        etag, cached = http_client._etag_cache['repos/test']
+        assert etag == '"page1-etag"'
+        assert cached == [{"id": 1}, {"id": 2}]
+
+    def test_etag_pagination_304_returns_full_cached(self, http_client):
+        """304 on paginated endpoint returns full cached result."""
+        http_client._etag_cache['repos/test'] = (
+            '"page1-etag"', [{"id": 1}, {"id": 2}]
+        )
+
+        response = Mock()
+        response.status_code = 304
+        response.headers = {'X-RateLimit-Remaining': '100'}
+        response.links = {}
+
+        with patch.object(http_client.session, 'get',
+                          return_value=response):
+            result = http_client.get('repos/test', use_etag=True)
+
+        # Returns full cached result (both pages)
+        assert result == [{"id": 1}, {"id": 2}]
+
+    def test_etag_pagination_no_etag_on_subsequent_pages(self, http_client):
+        """If-None-Match is only sent on the first page."""
+        http_client._etag_cache['repos/test'] = (
+            '"old-etag"', [{"id": 0}]
+        )
+
+        r1 = Mock()
+        r1.status_code = 200
+        r1.text = '[{"id": 1}]'
+        r1.headers = {
+            'X-RateLimit-Remaining': '100',
+            'ETag': '"new-etag"',
+        }
+        r1.links = {'next': {'url': 'https://api.github.com/page2'}}
+
+        r2 = Mock()
+        r2.status_code = 200
+        r2.text = '[{"id": 2}]'
+        r2.headers = {'X-RateLimit-Remaining': '99'}
+        r2.links = {}
+
+        with patch.object(http_client.session, 'get',
+                          side_effect=[r1, r2]) as mock_get:
+            http_client.get('repos/test', use_etag=True)
+
+        # First call has If-None-Match
+        first_headers = mock_get.call_args_list[0].kwargs['headers']
+        assert first_headers['If-None-Match'] == '"old-etag"'
+        # Second call does NOT have If-None-Match
+        second_headers = mock_get.call_args_list[1].kwargs['headers']
+        assert 'If-None-Match' not in second_headers
+
+    def test_etag_no_etag_header_in_response(self, http_client):
+        """Response without ETag header does not cache."""
+        response = Mock()
+        response.status_code = 200
+        response.text = '{"id": 1}'
+        response.headers = {'X-RateLimit-Remaining': '100'}
+        response.links = {}
+
+        with patch.object(http_client.session, 'get',
+                          return_value=response):
+            http_client.get('repos/test', use_etag=True)
+
+        assert 'repos/test' not in http_client._etag_cache
+
+    def test_etag_different_paths_independent(self, http_client):
+        """Different paths have independent cache entries."""
+        r1 = Mock()
+        r1.status_code = 200
+        r1.text = '{"branch": "main"}'
+        r1.headers = {
+            'X-RateLimit-Remaining': '100',
+            'ETag': '"etag-branches"',
+        }
+        r1.links = {}
+
+        r2 = Mock()
+        r2.status_code = 200
+        r2.text = '[{"name": "bug"}]'
+        r2.headers = {
+            'X-RateLimit-Remaining': '99',
+            'ETag': '"etag-labels"',
+        }
+        r2.links = {}
+
+        with patch.object(http_client.session, 'get', return_value=r1):
+            http_client.get('repos/test/branches', use_etag=True)
+        with patch.object(http_client.session, 'get', return_value=r2):
+            http_client.get('repos/test/labels', use_etag=True)
+
+        assert len(http_client._etag_cache) == 2
+        assert http_client._etag_cache['repos/test/branches'][0] == '"etag-branches"'
+        assert http_client._etag_cache['repos/test/labels'][0] == '"etag-labels"'
+
+    def test_etag_cache_empty_on_init(self, http_client):
+        """ETag cache starts empty."""
+        assert http_client._etag_cache == {}


### PR DESCRIPTION
Cache ETags from GET responses and send If-None-Match on subsequent requests.  304 Not Modified returns cached data at zero rate-limit cost.  Enable for branches, labels, commits, comments, and reviews.