### PR TITLE
Sync CI checks

### DIFF
--- a/examples/openshift-hubtty.yaml
+++ b/examples/openshift-hubtty.yaml
@@ -210,6 +210,13 @@ commentlinks:
 hide-comments:
   - author: "^.*openshift.*$"
 
+# Check context names whose "pending" state should be ignored when
+# deciding whether to keep polling for CI results.  "tide" is a
+# merge-gate status that stays pending until required labels are
+# applied -- it is not a CI job that will eventually complete.
+ignore-pending-checks:
+  - tide
+
 # This section defines customized dashboards.  You can supply any
 # Hubtty search string and bind them to any key.  They will appear in
 # the global help text, and pressing the key anywhere in Hubtty will

--- a/examples/reference-hubtty.yaml
+++ b/examples/reference-hubtty.yaml
@@ -198,6 +198,14 @@ commentlinks:
 # hide-comments:
 #  - author: "^(.*CI|Jenkins)$"
 
+# Hubtty re-polls CI checks while any check is still "pending".
+# Some status contexts (like "tide") remain pending indefinitely
+# because they reflect merge-gate conditions (labels, approvals)
+# rather than CI jobs.  List their names here to exclude them from
+# pending-check polling decisions.
+# ignore-pending-checks:
+#   - tide
+
 # This section defines customized dashboards.  You can supply any
 # Hubtty search string and bind them to any key.  They will appear in
 # the global help text, and pressing the key anywhere in Hubtty will

--- a/hubtty/config.py
+++ b/hubtty/config.py
@@ -126,6 +126,7 @@ class ConfigSchema:
                            'close-pr-on-review': bool,
                            'pr-list-options': self.pr_list_options,
                            'expire-age': str,
+                           'ignore-pending-checks': [str],
                            'size-column': self.size_column,
                            })
         return schema
@@ -229,6 +230,8 @@ class Config:
             'reverse': pr_list_options.get('reverse', False)}
 
         self.expire_age = self.config.get('expire-age', '2 months')
+
+        self.ignore_pending_checks = self.config.get('ignore-pending-checks', [])
 
         self.size_column = self.config.get('size-column', {})
         self.size_column['type'] = self.size_column.get('type', 'graph')

--- a/hubtty/sync/__init__.py
+++ b/hubtty/sync/__init__.py
@@ -56,7 +56,11 @@ from .tasks.repository import (
 )
 
 # Pull request tasks
-from .tasks.pull_request import SyncPullRequestTask, SyncOutdatedPullRequestsTask
+from .tasks.pull_request import (
+    SyncPullRequestTask,
+    SyncPullRequestChecksTask,
+    SyncOutdatedPullRequestsTask,
+)
 
 # Upload tasks
 from .tasks.upload import (
@@ -111,6 +115,7 @@ __all__ = [
     'SetRepositoryUpdatedTask',
     # Pull request tasks
     'SyncPullRequestTask',
+    'SyncPullRequestChecksTask',
     'SyncOutdatedPullRequestsTask',
     # Upload tasks
     'UploadReviewsTask',

--- a/hubtty/sync/queue.py
+++ b/hubtty/sync/queue.py
@@ -15,6 +15,8 @@
 
 """Thread-safe multi-priority queue for sync tasks."""
 
+import time
+
 from collections import OrderedDict, deque
 from threading import Condition
 from typing import Any, List, Type, TypeVar
@@ -67,21 +69,36 @@ class MultiQueue:
     def get(self) -> T:
         """Remove and return the highest-priority item.
 
-        Blocks until an item is available.
+        Blocks until an item is available.  Items whose ``earliest_run``
+        attribute is in the future are skipped so that they do not block
+        higher-priority work.
 
         Returns:
             The highest-priority item from the queue.
         """
         with self.condition:
             while True:
+                soonest = None
                 for q in self.queues.values():
-                    try:
-                        ret = q.popleft()
-                        self.incomplete.append(ret)
-                        return ret
-                    except IndexError:
-                        pass
-                self.condition.wait()
+                    for i, item in enumerate(q):
+                        ready_at = getattr(item, 'earliest_run', 0) or 0
+                        if ready_at > time.time():
+                            # Track the earliest delayed item so we
+                            # can sleep only until it becomes ready.
+                            if soonest is None or ready_at < soonest:
+                                soonest = ready_at
+                            continue
+                        # Found a ready item – remove it from the deque.
+                        del q[i]
+                        self.incomplete.append(item)
+                        return item
+                # Nothing ready right now – wait until the earliest
+                # delayed item matures or a new item arrives.
+                if soonest is not None:
+                    wait_time = max(0, soonest - time.time())
+                    self.condition.wait(timeout=wait_time)
+                else:
+                    self.condition.wait()
 
     def find(self, klass: Type[T], priority: int) -> List[T]:
         """Find all items of a given class at a specific priority level.

--- a/hubtty/sync/task.py
+++ b/hubtty/sync/task.py
@@ -22,6 +22,7 @@ generates __eq__ and __repr__ methods for subclasses, reducing boilerplate.
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, TYPE_CHECKING
 import logging
+import time
 import threading
 
 from .constants import NORMAL_PRIORITY
@@ -57,6 +58,7 @@ class Task:
     # Priority is keyword-only with a default, so subclasses can have
     # positional fields without defaults
     priority: int = field(default=NORMAL_PRIORITY, compare=False, repr=False)
+    delay: float = field(default=0, compare=False, repr=False)
 
     # Runtime state - not part of task identity
     succeeded: Optional[bool] = field(default=None, init=False, compare=False, repr=False)
@@ -70,6 +72,11 @@ class Task:
         """Initialize the logger after dataclass initialization."""
         # Use object.__setattr__ in case the dataclass is frozen
         object.__setattr__(self, 'log', logging.getLogger('hubtty.sync'))
+        # Compute the earliest time this task may run
+        object.__setattr__(
+            self, 'earliest_run',
+            time.time() + self.delay if self.delay > 0 else 0
+        )
 
     @property
     def log(self) -> logging.Logger:

--- a/hubtty/sync/tasks/check_helpers.py
+++ b/hubtty/sync/tasks/check_helpers.py
@@ -1,0 +1,175 @@
+# Copyright 2014 OpenStack Foundation
+# Copyright 2014 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Shared helper functions for CI check synchronization."""
+
+import logging
+from typing import Any, Dict, List, TYPE_CHECKING
+
+import dateutil.parser
+
+if TYPE_CHECKING:
+    from ..sync import Sync
+
+log = logging.getLogger(__name__)
+
+
+def check_result_from_check_run(remote_check: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a GitHub check run to internal format.
+
+    Args:
+        remote_check: Check run data from GitHub API.
+
+    Returns:
+        Normalized check data dictionary.
+    """
+    check = {}
+    check['name'] = remote_check['name']
+    check['url'] = remote_check.get('html_url', '')
+    if remote_check['status'] == 'completed':
+        check['state'] = remote_check['conclusion']
+    else:
+        check['state'] = 'pending'
+    # Set message according to status
+    if check['state'] == 'success':
+        check['message'] = 'Job succeeded'
+    elif check['state'] == 'failure':
+        check['message'] = 'Job failed'
+    else:
+        check['message'] = 'Job triggered'
+
+    started = remote_check.get('started_at')
+    if started:
+        check['started'] = started
+        check['created'] = started
+        check['updated'] = started
+    finished = remote_check.get('completed_at')
+    if finished:
+        check['finished'] = finished
+        check['updated'] = finished
+
+    return check
+
+
+def check_result_from_status(remote_check: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a GitHub commit status to internal format.
+
+    Args:
+        remote_check: Commit status data from GitHub API.
+
+    Returns:
+        Normalized check data dictionary.
+    """
+    check = {}
+    check['name'] = remote_check['context']
+    check['url'] = remote_check.get('target_url', '')
+    check['state'] = remote_check['state']
+    check['message'] = remote_check.get('description', '')
+
+    check['created'] = remote_check['created_at']
+    check['updated'] = remote_check['updated_at']
+
+    return check
+
+
+def update_checks(session, commit, remote_checks_data: List[Dict[str, Any]]) -> None:
+    """Update checks for a commit.
+
+    Args:
+        session: Database session.
+        commit: The commit to update checks for.
+        remote_checks_data: List of check data from GitHub.
+    """
+    # Delete outdated checks
+    remote_check_names = [c['name'] for c in remote_checks_data]
+    for check in commit.checks:
+        if check.name not in remote_check_names:
+            log.info("Deleted check %s", check.key)
+            session.delete(check)
+
+    local_checks = {c.name: c for c in commit.checks}
+    for check_data in remote_checks_data:
+        check = local_checks.get(check_data['name'])
+        if check is None:
+            created = dateutil.parser.parse(check_data['created'])
+            log.info(
+                "Creating check %s on commit %s",
+                check_data['name'], commit.key
+            )
+            check = commit.createCheck(
+                check_data['name'],
+                check_data['state'], created, created
+            )
+        check.updated = dateutil.parser.parse(check_data['updated'])
+        check.state = check_data['state']
+        check.url = check_data['url']
+        check.message = check_data['message']
+
+        started = check_data.get('started')
+        if started:
+            check.started = dateutil.parser.parse(check_data['started'])
+        finished = check_data.get('finished')
+        if finished:
+            check.finished = dateutil.parser.parse(check_data['finished'])
+
+
+def fetch_checks(sync: 'Sync', repository_name: str,
+                 commit_sha: str,
+                 use_etag: bool = True) -> List[Dict[str, Any]]:
+    """Fetch CI checks for a commit from GitHub.
+
+    Fetches both commit statuses and check runs, normalizing them
+    into a common format.  Uses conditional requests (ETags) by
+    default so that repeated polls for the same commit are cheap.
+
+    Args:
+        sync: The Sync instance to use for API calls.
+        repository_name: Full repository name (e.g. 'owner/repo').
+        commit_sha: The commit SHA to fetch checks for.
+        use_etag: Enable conditional requests via ETag / If-None-Match.
+
+    Returns:
+        List of normalized check data dictionaries.
+    """
+    checks = []
+    remote_commit_status = sync.get(
+        f'repos/{repository_name}/commits/{commit_sha}/status',
+        use_etag=use_etag,
+    )
+    if remote_commit_status is not None:
+        for check in remote_commit_status['statuses']:
+            checks.append(check_result_from_status(check))
+
+    remote_commit_check_runs = sync.get(
+        f'repos/{repository_name}/commits/{commit_sha}/check-runs',
+        use_etag=use_etag,
+    )
+    if remote_commit_check_runs is not None:
+        for check in remote_commit_check_runs['check_runs']:
+            checks.append(check_result_from_check_run(check))
+
+    return checks
+
+
+def has_pending_checks(checks_data: List[Dict[str, Any]]) -> bool:
+    """Check if any checks are still in pending state.
+
+    Args:
+        checks_data: List of normalized check data dictionaries.
+
+    Returns:
+        True if any check has state 'pending'.
+    """
+    return any(c['state'] == 'pending' for c in checks_data)

--- a/hubtty/sync/tasks/check_helpers.py
+++ b/hubtty/sync/tasks/check_helpers.py
@@ -163,13 +163,18 @@ def fetch_checks(sync: 'Sync', repository_name: str,
     return checks
 
 
-def has_pending_checks(checks_data: List[Dict[str, Any]]) -> bool:
+def has_pending_checks(checks_data: List[Dict[str, Any]],
+                       ignore_names: frozenset = frozenset()) -> bool:
     """Check if any checks are still in pending state.
 
     Args:
         checks_data: List of normalized check data dictionaries.
+        ignore_names: Set of check names whose pending state should
+            be ignored (e.g. merge-gate contexts like ``tide`` that
+            stay pending until labels are applied).
 
     Returns:
-        True if any check has state 'pending'.
+        True if any check has state 'pending' and is not ignored.
     """
-    return any(c['state'] == 'pending' for c in checks_data)
+    return any(c['state'] == 'pending' and c['name'] not in ignore_names
+               for c in checks_data)

--- a/hubtty/sync/tasks/pull_request.py
+++ b/hubtty/sync/tasks/pull_request.py
@@ -17,7 +17,7 @@
 
 import time
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import dateutil.parser
@@ -59,7 +59,7 @@ class SyncPullRequestTask(Task):
     """Sync a specific pull request from GitHub."""
 
     pr_id: str
-    force_fetch: bool = False
+    force_fetch: bool = field(default=False, compare=False)
 
     def run(self, sync: 'Sync') -> None:
         """Sync the pull request from GitHub.
@@ -454,7 +454,7 @@ class SyncPullRequestChecksTask(Task):
 
     pr_id: str
     repository_name: str
-    attempt: int = 0
+    attempt: int = field(default=0, compare=False)
 
     # Back-off schedule (seconds) indexed by attempt number.
     # After the list is exhausted the last value is reused.

--- a/hubtty/sync/tasks/pull_request.py
+++ b/hubtty/sync/tasks/pull_request.py
@@ -425,7 +425,9 @@ class SyncPullRequestTask(Task):
             # re-check so we pick up completed CI results without
             # waiting for another full PR sync.
             if (len(remote_commits) > 0
-                    and has_pending_checks(last_commit.get('_hubtty_checks', []))):
+                    and has_pending_checks(
+                        last_commit.get('_hubtty_checks', []),
+                        frozenset(sync.app.config.ignore_pending_checks))):
                 self.log.info(
                     "Pull request %s has pending checks, scheduling re-check",
                     self.pr_id
@@ -500,7 +502,8 @@ class SyncPullRequestChecksTask(Task):
         self.results.append(PullRequestUpdatedEvent(repository_key, pr_key))
 
         # Re-submit if checks are still pending
-        if has_pending_checks(checks_data):
+        if has_pending_checks(checks_data,
+                               frozenset(sync.app.config.ignore_pending_checks)):
             if self.attempt + 1 < MAX_CHECK_RETRIES:
                 delay = self._BACKOFF[min(self.attempt, len(self._BACKOFF) - 1)]
                 self.log.info(

--- a/hubtty/sync/tasks/pull_request.py
+++ b/hubtty/sync/tasks/pull_request.py
@@ -18,16 +18,24 @@
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import dateutil.parser
 
 from hubtty import gitrepo
 from ..task import Task
+from ..constants import LOW_PRIORITY
 from ..events import RepositoryAddedEvent, PullRequestAddedEvent, PullRequestUpdatedEvent
+from .check_helpers import (
+    fetch_checks,
+    has_pending_checks,
+    update_checks,
+)
 
 if TYPE_CHECKING:
     from ..sync import Sync
+
+MAX_CHECK_RETRIES = 20
 
 
 @dataclass
@@ -52,104 +60,6 @@ class SyncPullRequestTask(Task):
 
     pr_id: str
     force_fetch: bool = False
-
-    def _checkResultFromCheck(self, remote_check: Dict[str, Any]) -> Dict[str, Any]:
-        """Convert a GitHub check run to internal format.
-
-        Args:
-            remote_check: Check run data from GitHub API.
-
-        Returns:
-            Normalized check data dictionary.
-        """
-        check = {}
-        check['name'] = remote_check['name']
-        check['url'] = remote_check.get('html_url', '')
-        if remote_check['status'] == 'completed':
-            check['state'] = remote_check['conclusion']
-        else:
-            check['state'] = 'pending'
-        # Set message according to status
-        if check['state'] == 'success':
-            check['message'] = 'Job succeeded'
-        elif check['state'] == 'failure':
-            check['message'] = 'Job failed'
-        else:
-            check['message'] = 'Job triggered'
-
-        started = remote_check.get('started_at')
-        if started:
-            check['started'] = started
-            check['created'] = started
-            check['updated'] = started
-        finished = remote_check.get('completed_at')
-        if finished:
-            check['finished'] = finished
-            check['updated'] = finished
-
-        return check
-
-    def _checkResultFromStatus(self, remote_check: Dict[str, Any]) -> Dict[str, Any]:
-        """Convert a GitHub commit status to internal format.
-
-        Args:
-            remote_check: Commit status data from GitHub API.
-
-        Returns:
-            Normalized check data dictionary.
-        """
-        check = {}
-        check['name'] = remote_check['context']
-        check['url'] = remote_check.get('target_url', '')
-        check['state'] = remote_check['state']
-        check['message'] = remote_check.get('description', '')
-
-        check['created'] = remote_check['created_at']
-        check['updated'] = remote_check['updated_at']
-
-        return check
-
-    def _updateChecks(
-        self, session, commit, remote_checks_data: List[Dict[str, Any]]
-    ) -> None:
-        """Update checks for a commit.
-
-        Args:
-            session: Database session.
-            commit: The commit to update checks for.
-            remote_checks_data: List of check data from GitHub.
-        """
-        # Delete outdated checks
-        remote_check_names = [c['name'] for c in remote_checks_data]
-        for check in commit.checks:
-            if check.name not in remote_check_names:
-                self.log.info("Deleted check %s", check.key)
-                session.delete(check)
-
-        local_checks = {c.name: c for c in commit.checks}
-        for check_data in remote_checks_data:
-            check = local_checks.get(check_data['name'])
-            if check is None:
-                created = dateutil.parser.parse(check_data['created'])
-                self.log.info(
-                    "Creating check %s on commit %s",
-                    check_data['name'], commit.key
-                )
-                check = commit.createCheck(
-                    check_data['name'],
-                    check_data['state'], created, created
-                )
-            check.updated = dateutil.parser.parse(check_data['updated'])
-            check.state = check_data['state']
-            check.url = check_data['url']
-            check.message = check_data['message']
-
-            started = check_data.get('started')
-            if started:
-                check.started = dateutil.parser.parse(check_data['started'])
-            finished = check_data.get('finished')
-            if finished:
-                check.finished = dateutil.parser.parse(check_data['finished'])
 
     def run(self, sync: 'Sync') -> None:
         """Sync the pull request from GitHub.
@@ -217,21 +127,9 @@ class SyncPullRequestTask(Task):
         # PR might have been rebased and no longer contain commits
         if len(remote_commits) > 0:
             last_commit = remote_commits[-1]
-            last_commit['_hubtty_checks'] = []
-            remote_commit_status = sync.get(
-                f'repos/{repository_name}/commits/{last_commit["sha"]}/status'
+            last_commit['_hubtty_checks'] = fetch_checks(
+                sync, repository_name, last_commit['sha']
             )
-            for check in remote_commit_status['statuses']:
-                last_commit['_hubtty_checks'].append(
-                    self._checkResultFromStatus(check)
-                )
-            remote_commit_check_runs = sync.get(
-                f'repos/{repository_name}/commits/{last_commit["sha"]}/check-runs'
-            )
-            for check in remote_commit_check_runs['check_runs']:
-                last_commit['_hubtty_checks'].append(
-                    self._checkResultFromCheck(check)
-                )
 
         fetches = defaultdict(list)
         with app.db.getSession() as session:
@@ -361,7 +259,7 @@ class SyncPullRequestTask(Task):
 
                 # Commit checks
                 if remote_commit.get('_hubtty_checks'):
-                    self._updateChecks(
+                    update_checks(
                         session, commit, remote_commit['_hubtty_checks']
                     )
 
@@ -522,6 +420,108 @@ class SyncPullRequestTask(Task):
                     session.delete(commit)
 
             pr.outdated = False
+
+            # If any checks are still pending, schedule a lightweight
+            # re-check so we pick up completed CI results without
+            # waiting for another full PR sync.
+            if (len(remote_commits) > 0
+                    and has_pending_checks(last_commit.get('_hubtty_checks', []))):
+                self.log.info(
+                    "Pull request %s has pending checks, scheduling re-check",
+                    self.pr_id
+                )
+                sync.submitTask(SyncPullRequestChecksTask(
+                    pr.pr_id,
+                    pr.repository.name,
+                    priority=LOW_PRIORITY,
+                ))
+
         for url, refs in fetches.items():
             self.log.debug("Fetching from %s with refs %s", url, refs)
             repo.fetch(url, refs)
+
+
+@dataclass
+class SyncPullRequestChecksTask(Task):
+    """Lightweight task to re-fetch only CI checks for a PR's last commit.
+
+    This avoids a full PR sync when the only thing that may have changed
+    is the CI status.  The task re-submits itself (with back-off) while
+    checks remain in *pending* state, up to MAX_CHECK_RETRIES attempts.
+    """
+
+    pr_id: str
+    repository_name: str
+    attempt: int = 0
+
+    # Back-off schedule (seconds) indexed by attempt number.
+    # After the list is exhausted the last value is reused.
+    _BACKOFF = [30, 60, 60, 120, 120, 120, 300, 300, 300, 300]
+
+    def run(self, sync: 'Sync') -> None:
+        """Fetch checks for the last commit and update the local DB.
+
+        If checks are still pending and we have not exceeded
+        MAX_CHECK_RETRIES, sleep for a back-off interval and
+        re-submit ourselves.
+
+        Args:
+            sync: The Sync instance to use for API calls.
+        """
+        app = sync.app
+
+        with app.db.getSession() as session:
+            pr = session.getPullRequestByPullRequestID(self.pr_id)
+            if pr is None:
+                self.log.warning(
+                    "PR %s no longer exists locally, skipping check sync",
+                    self.pr_id,
+                )
+                return
+            if not pr.commits:
+                return
+            last_commit = pr.commits[-1]
+            commit_sha = last_commit.sha
+            pr_key = pr.key
+            repository_key = pr.repository.key
+
+        # Fetch checks from GitHub (outside the DB session)
+        checks_data = fetch_checks(sync, self.repository_name, commit_sha)
+
+        # Write back into the DB
+        with app.db.getSession() as session:
+            pr = session.getPullRequestByPullRequestID(self.pr_id)
+            if pr is None or not pr.commits:
+                return
+            last_commit = pr.commits[-1]
+            update_checks(session, last_commit, checks_data)
+
+        # Notify the UI
+        self.results.append(PullRequestUpdatedEvent(repository_key, pr_key))
+
+        # Re-submit if checks are still pending
+        if has_pending_checks(checks_data):
+            if self.attempt + 1 < MAX_CHECK_RETRIES:
+                delay = self._BACKOFF[min(self.attempt, len(self._BACKOFF) - 1)]
+                self.log.info(
+                    "Checks still pending for %s (attempt %d/%d), "
+                    "retrying in %ds",
+                    self.pr_id, self.attempt + 1, MAX_CHECK_RETRIES, delay,
+                )
+                sync.submitTask(SyncPullRequestChecksTask(
+                    self.pr_id,
+                    self.repository_name,
+                    attempt=self.attempt + 1,
+                    priority=self.priority,
+                    delay=delay,
+                ))
+            else:
+                self.log.warning(
+                    "Giving up on pending checks for %s after %d attempts",
+                    self.pr_id, MAX_CHECK_RETRIES,
+                )
+        else:
+            self.log.info(
+                "All checks completed for %s after %d attempt(s)",
+                self.pr_id, self.attempt + 1,
+            )

--- a/hubtty/sync/tasks/repository_check.py
+++ b/hubtty/sync/tasks/repository_check.py
@@ -15,7 +15,7 @@
 
 """Repository checking tasks for startup validation."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from hubtty import gitrepo
@@ -68,7 +68,7 @@ class CheckCommitsTask(Task):
     """Check commits in a repository for missing refs."""
 
     repository_key: int
-    force_fetch: bool = False
+    force_fetch: bool = field(default=False, compare=False)
 
     def run(self, sync: 'Sync') -> None:
         """Check for missing commits and submit sync tasks.

--- a/tests/sync/test_check_helpers.py
+++ b/tests/sync/test_check_helpers.py
@@ -239,6 +239,36 @@ class TestHasPendingChecks:
         ]
         assert has_pending_checks(checks) is False
 
+    def test_ignored_pending_not_counted(self):
+        """A pending check in the ignore set is not counted."""
+        checks = [
+            {'state': 'success', 'name': 'ci/build'},
+            {'state': 'pending', 'name': 'tide'},
+        ]
+        assert has_pending_checks(checks, frozenset(['tide'])) is False
+
+    def test_ignored_plus_real_pending(self):
+        """Ignored pending + non-ignored pending returns True."""
+        checks = [
+            {'state': 'pending', 'name': 'tide'},
+            {'state': 'pending', 'name': 'ci/build'},
+        ]
+        assert has_pending_checks(checks, frozenset(['tide'])) is True
+
+    def test_ignored_name_not_in_list(self):
+        """Pending check not in ignore set is still counted."""
+        checks = [
+            {'state': 'pending', 'name': 'ci/build'},
+        ]
+        assert has_pending_checks(checks, frozenset(['tide'])) is True
+
+    def test_empty_ignore_set_default_behavior(self):
+        """Default empty frozenset preserves original behavior."""
+        checks = [
+            {'state': 'pending', 'name': 'tide'},
+        ]
+        assert has_pending_checks(checks) is True
+
 
 class TestFetchChecks:
     """Tests for fetch_checks."""

--- a/tests/sync/test_check_helpers.py
+++ b/tests/sync/test_check_helpers.py
@@ -1,0 +1,456 @@
+# Copyright 2014 OpenStack Foundation
+# Copyright 2014 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Tests for check_helpers module."""
+
+from unittest.mock import Mock
+
+import dateutil.parser
+
+from hubtty.sync.tasks.check_helpers import (
+    check_result_from_check_run,
+    check_result_from_status,
+    fetch_checks,
+    has_pending_checks,
+    update_checks,
+)
+
+
+class TestCheckResultFromCheckRun:
+    """Tests for check_result_from_check_run."""
+
+    def test_completed_success(self):
+        """Completed check run with success conclusion."""
+        remote = {
+            'name': 'ci/test',
+            'html_url': 'https://example.com/run/1',
+            'status': 'completed',
+            'conclusion': 'success',
+            'started_at': '2024-01-01T10:00:00Z',
+            'completed_at': '2024-01-01T10:05:00Z',
+        }
+        result = check_result_from_check_run(remote)
+        assert result['name'] == 'ci/test'
+        assert result['url'] == 'https://example.com/run/1'
+        assert result['state'] == 'success'
+        assert result['message'] == 'Job succeeded'
+        assert result['started'] == '2024-01-01T10:00:00Z'
+        assert result['finished'] == '2024-01-01T10:05:00Z'
+
+    def test_completed_failure(self):
+        """Completed check run with failure conclusion."""
+        remote = {
+            'name': 'ci/build',
+            'html_url': 'https://example.com/run/2',
+            'status': 'completed',
+            'conclusion': 'failure',
+            'started_at': '2024-01-01T10:00:00Z',
+            'completed_at': '2024-01-01T10:03:00Z',
+        }
+        result = check_result_from_check_run(remote)
+        assert result['state'] == 'failure'
+        assert result['message'] == 'Job failed'
+
+    def test_in_progress_is_pending(self):
+        """In-progress check run maps to pending state."""
+        remote = {
+            'name': 'ci/lint',
+            'status': 'in_progress',
+            'started_at': '2024-01-01T10:00:00Z',
+        }
+        result = check_result_from_check_run(remote)
+        assert result['state'] == 'pending'
+        assert result['message'] == 'Job triggered'
+
+    def test_queued_is_pending(self):
+        """Queued check run maps to pending state."""
+        remote = {
+            'name': 'ci/deploy',
+            'status': 'queued',
+        }
+        result = check_result_from_check_run(remote)
+        assert result['state'] == 'pending'
+        assert result['message'] == 'Job triggered'
+
+    def test_missing_url_defaults_empty(self):
+        """Missing html_url defaults to empty string."""
+        remote = {
+            'name': 'ci/test',
+            'status': 'completed',
+            'conclusion': 'success',
+        }
+        result = check_result_from_check_run(remote)
+        assert result['url'] == ''
+
+    def test_no_timestamps(self):
+        """Check run without timestamps has no started/finished/created."""
+        remote = {
+            'name': 'ci/test',
+            'status': 'queued',
+        }
+        result = check_result_from_check_run(remote)
+        assert 'started' not in result
+        assert 'finished' not in result
+        assert 'created' not in result
+
+    def test_started_sets_created_and_updated(self):
+        """started_at populates created and updated fields."""
+        remote = {
+            'name': 'ci/test',
+            'status': 'in_progress',
+            'started_at': '2024-06-01T12:00:00Z',
+        }
+        result = check_result_from_check_run(remote)
+        assert result['created'] == '2024-06-01T12:00:00Z'
+        assert result['updated'] == '2024-06-01T12:00:00Z'
+
+    def test_completed_at_overrides_updated(self):
+        """completed_at overrides updated field set by started_at."""
+        remote = {
+            'name': 'ci/test',
+            'status': 'completed',
+            'conclusion': 'success',
+            'started_at': '2024-06-01T12:00:00Z',
+            'completed_at': '2024-06-01T12:05:00Z',
+        }
+        result = check_result_from_check_run(remote)
+        assert result['updated'] == '2024-06-01T12:05:00Z'
+        assert result['created'] == '2024-06-01T12:00:00Z'
+
+
+class TestCheckResultFromStatus:
+    """Tests for check_result_from_status."""
+
+    def test_success_status(self):
+        """Successful commit status."""
+        remote = {
+            'context': 'ci/circleci',
+            'target_url': 'https://circleci.com/build/1',
+            'state': 'success',
+            'description': 'All tests passed',
+            'created_at': '2024-01-01T10:00:00Z',
+            'updated_at': '2024-01-01T10:05:00Z',
+        }
+        result = check_result_from_status(remote)
+        assert result['name'] == 'ci/circleci'
+        assert result['url'] == 'https://circleci.com/build/1'
+        assert result['state'] == 'success'
+        assert result['message'] == 'All tests passed'
+        assert result['created'] == '2024-01-01T10:00:00Z'
+        assert result['updated'] == '2024-01-01T10:05:00Z'
+
+    def test_pending_status(self):
+        """Pending commit status."""
+        remote = {
+            'context': 'ci/jenkins',
+            'state': 'pending',
+            'description': 'Build queued',
+            'created_at': '2024-01-01T10:00:00Z',
+            'updated_at': '2024-01-01T10:00:00Z',
+        }
+        result = check_result_from_status(remote)
+        assert result['state'] == 'pending'
+        assert result['message'] == 'Build queued'
+
+    def test_failure_status(self):
+        """Failed commit status."""
+        remote = {
+            'context': 'ci/test',
+            'state': 'failure',
+            'description': '3 tests failed',
+            'created_at': '2024-01-01T10:00:00Z',
+            'updated_at': '2024-01-01T10:05:00Z',
+        }
+        result = check_result_from_status(remote)
+        assert result['state'] == 'failure'
+
+    def test_missing_url_defaults_empty(self):
+        """Missing target_url defaults to empty string."""
+        remote = {
+            'context': 'ci/test',
+            'state': 'success',
+            'description': 'ok',
+            'created_at': '2024-01-01T10:00:00Z',
+            'updated_at': '2024-01-01T10:05:00Z',
+        }
+        result = check_result_from_status(remote)
+        assert result['url'] == ''
+
+    def test_missing_description_defaults_empty(self):
+        """Missing description defaults to empty string."""
+        remote = {
+            'context': 'ci/test',
+            'state': 'success',
+            'created_at': '2024-01-01T10:00:00Z',
+            'updated_at': '2024-01-01T10:05:00Z',
+        }
+        result = check_result_from_status(remote)
+        assert result['message'] == ''
+
+
+class TestHasPendingChecks:
+    """Tests for has_pending_checks."""
+
+    def test_empty_list(self):
+        """Empty list has no pending checks."""
+        assert has_pending_checks([]) is False
+
+    def test_all_success(self):
+        """All success means no pending."""
+        checks = [
+            {'state': 'success', 'name': 'a'},
+            {'state': 'success', 'name': 'b'},
+        ]
+        assert has_pending_checks(checks) is False
+
+    def test_one_pending(self):
+        """One pending check is detected."""
+        checks = [
+            {'state': 'success', 'name': 'a'},
+            {'state': 'pending', 'name': 'b'},
+        ]
+        assert has_pending_checks(checks) is True
+
+    def test_all_pending(self):
+        """All pending returns True."""
+        checks = [
+            {'state': 'pending', 'name': 'a'},
+            {'state': 'pending', 'name': 'b'},
+        ]
+        assert has_pending_checks(checks) is True
+
+    def test_mixed_states_no_pending(self):
+        """Mix of success/failure but no pending."""
+        checks = [
+            {'state': 'success', 'name': 'a'},
+            {'state': 'failure', 'name': 'b'},
+        ]
+        assert has_pending_checks(checks) is False
+
+
+class TestFetchChecks:
+    """Tests for fetch_checks."""
+
+    def test_fetches_statuses_and_check_runs(self):
+        """Fetches both commit statuses and check runs."""
+        sync = Mock()
+        sync.get.side_effect = [
+            # commit status response
+            {'statuses': [
+                {'context': 'ci/status', 'target_url': 'http://x',
+                 'state': 'success', 'description': 'ok',
+                 'created_at': '2024-01-01T10:00:00Z',
+                 'updated_at': '2024-01-01T10:05:00Z'},
+            ]},
+            # check runs response
+            {'check_runs': [
+                {'name': 'ci/check', 'html_url': 'http://y',
+                 'status': 'completed', 'conclusion': 'failure',
+                 'started_at': '2024-01-01T10:00:00Z',
+                 'completed_at': '2024-01-01T10:03:00Z'},
+            ]},
+        ]
+        result = fetch_checks(sync, 'owner/repo', 'abc123')
+        assert len(result) == 2
+        assert result[0]['name'] == 'ci/status'
+        assert result[0]['state'] == 'success'
+        assert result[1]['name'] == 'ci/check'
+        assert result[1]['state'] == 'failure'
+
+        # Verify API calls
+        assert sync.get.call_count == 2
+        sync.get.assert_any_call(
+            'repos/owner/repo/commits/abc123/status', use_etag=True)
+        sync.get.assert_any_call(
+            'repos/owner/repo/commits/abc123/check-runs', use_etag=True)
+
+    def test_empty_statuses_and_check_runs(self):
+        """Returns empty list when no checks exist."""
+        sync = Mock()
+        sync.get.side_effect = [
+            {'statuses': []},
+            {'check_runs': []},
+        ]
+        result = fetch_checks(sync, 'owner/repo', 'abc123')
+        assert result == []
+
+    def test_only_statuses(self):
+        """Returns only statuses when no check runs."""
+        sync = Mock()
+        sync.get.side_effect = [
+            {'statuses': [
+                {'context': 'ci/only', 'state': 'pending',
+                 'description': 'waiting',
+                 'created_at': '2024-01-01T10:00:00Z',
+                 'updated_at': '2024-01-01T10:00:00Z'},
+            ]},
+            {'check_runs': []},
+        ]
+        result = fetch_checks(sync, 'owner/repo', 'abc123')
+        assert len(result) == 1
+        assert result[0]['name'] == 'ci/only'
+
+
+class TestUpdateChecks:
+    """Tests for update_checks."""
+
+    def _make_check(self, name, state='success'):
+        """Create a mock check object."""
+        check = Mock()
+        check.name = name
+        check.key = f'key-{name}'
+        check.state = state
+        return check
+
+    def _make_commit(self, checks):
+        """Create a mock commit with checks."""
+        commit = Mock()
+        commit.checks = list(checks)
+        commit.key = 'commit-1'
+        return commit
+
+    def test_creates_new_check(self):
+        """New check is created when not in local DB."""
+        session = Mock()
+        commit = self._make_commit([])
+        new_check = Mock()
+        commit.createCheck.return_value = new_check
+
+        checks_data = [{
+            'name': 'ci/new',
+            'state': 'success',
+            'url': 'http://x',
+            'message': 'Job succeeded',
+            'created': '2024-01-01T10:00:00Z',
+            'updated': '2024-01-01T10:05:00Z',
+        }]
+        update_checks(session, commit, checks_data)
+
+        commit.createCheck.assert_called_once_with(
+            'ci/new', 'success',
+            dateutil.parser.parse('2024-01-01T10:00:00Z'),
+            dateutil.parser.parse('2024-01-01T10:00:00Z'),
+        )
+        assert new_check.state == 'success'
+        assert new_check.url == 'http://x'
+        assert new_check.message == 'Job succeeded'
+
+    def test_updates_existing_check(self):
+        """Existing check is updated with new state."""
+        session = Mock()
+        existing = self._make_check('ci/test', 'pending')
+        commit = self._make_commit([existing])
+
+        checks_data = [{
+            'name': 'ci/test',
+            'state': 'success',
+            'url': 'http://x',
+            'message': 'Job succeeded',
+            'created': '2024-01-01T10:00:00Z',
+            'updated': '2024-01-01T10:05:00Z',
+        }]
+        update_checks(session, commit, checks_data)
+
+        assert existing.state == 'success'
+        assert existing.url == 'http://x'
+        assert existing.message == 'Job succeeded'
+        commit.createCheck.assert_not_called()
+
+    def test_deletes_removed_check(self):
+        """Check not in remote data is deleted."""
+        session = Mock()
+        old_check = self._make_check('ci/old')
+        commit = self._make_commit([old_check])
+
+        checks_data = [{
+            'name': 'ci/new',
+            'state': 'success',
+            'url': '',
+            'message': 'ok',
+            'created': '2024-01-01T10:00:00Z',
+            'updated': '2024-01-01T10:05:00Z',
+        }]
+        commit.createCheck.return_value = Mock()
+        update_checks(session, commit, checks_data)
+
+        session.delete.assert_called_once_with(old_check)
+
+    def test_sets_started_and_finished(self):
+        """started and finished timestamps are set when present."""
+        session = Mock()
+        commit = self._make_commit([])
+        new_check = Mock()
+        commit.createCheck.return_value = new_check
+
+        checks_data = [{
+            'name': 'ci/test',
+            'state': 'success',
+            'url': '',
+            'message': 'ok',
+            'created': '2024-01-01T10:00:00Z',
+            'updated': '2024-01-01T10:05:00Z',
+            'started': '2024-01-01T10:00:00Z',
+            'finished': '2024-01-01T10:05:00Z',
+        }]
+        update_checks(session, commit, checks_data)
+
+        assert new_check.started == dateutil.parser.parse('2024-01-01T10:00:00Z')
+        assert new_check.finished == dateutil.parser.parse('2024-01-01T10:05:00Z')
+
+    def test_no_started_or_finished(self):
+        """started/finished not set when absent from data."""
+        session = Mock()
+        existing = self._make_check('ci/test', 'pending')
+        # Reset started/finished so we can verify they're not touched
+        existing.started = None
+        existing.finished = None
+        commit = self._make_commit([existing])
+
+        checks_data = [{
+            'name': 'ci/test',
+            'state': 'pending',
+            'url': '',
+            'message': 'Job triggered',
+            'created': '2024-01-01T10:00:00Z',
+            'updated': '2024-01-01T10:00:00Z',
+        }]
+        update_checks(session, commit, checks_data)
+
+        assert existing.started is None
+        assert existing.finished is None
+
+    def test_multiple_checks(self):
+        """Multiple checks are handled correctly."""
+        session = Mock()
+        existing = self._make_check('ci/keep', 'pending')
+        stale = self._make_check('ci/stale')
+        commit = self._make_commit([existing, stale])
+        new_check = Mock()
+        commit.createCheck.return_value = new_check
+
+        checks_data = [
+            {'name': 'ci/keep', 'state': 'success', 'url': '', 'message': 'ok',
+             'created': '2024-01-01T10:00:00Z', 'updated': '2024-01-01T10:05:00Z'},
+            {'name': 'ci/brand-new', 'state': 'pending', 'url': '', 'message': 'triggered',
+             'created': '2024-01-01T10:00:00Z', 'updated': '2024-01-01T10:00:00Z'},
+        ]
+        update_checks(session, commit, checks_data)
+
+        # ci/stale should be deleted
+        session.delete.assert_called_once_with(stale)
+        # ci/keep should be updated
+        assert existing.state == 'success'
+        # ci/brand-new should be created
+        commit.createCheck.assert_called_once()

--- a/tests/sync/test_queue.py
+++ b/tests/sync/test_queue.py
@@ -17,6 +17,7 @@
 
 import threading
 import time
+from types import SimpleNamespace
 
 from hubtty.sync.queue import MultiQueue
 from hubtty.sync.constants import HIGH_PRIORITY, NORMAL_PRIORITY, LOW_PRIORITY
@@ -223,3 +224,60 @@ class TestMultiQueueThreadSafety:
 
         assert result == ["delayed"]
         assert elapsed >= 0.04  # Should have waited
+
+
+def _make_item(value, earliest_run=0):
+    """Create a simple object with earliest_run for delay testing."""
+    obj = SimpleNamespace(value=value, earliest_run=earliest_run)
+    # __eq__ and __hash__ based on value so duplicate detection works
+    obj.__eq__ = lambda self, other: getattr(other, 'value', None) == self.value
+    obj.__hash__ = lambda self: hash(self.value)
+    return obj
+
+
+class TestMultiQueueDelayed:
+    """Tests for delayed (earliest_run) items."""
+
+    def test_delayed_item_skipped_for_ready_item(self):
+        """A delayed item is skipped in favour of a later ready item."""
+        q = MultiQueue([NORMAL_PRIORITY, LOW_PRIORITY])
+        delayed = _make_item("delayed", earliest_run=time.time() + 60)
+        ready = _make_item("ready", earliest_run=0)
+
+        q.put(delayed, NORMAL_PRIORITY)
+        q.put(ready, LOW_PRIORITY)
+
+        item = q.get()
+        assert item.value == "ready"
+
+    def test_delayed_item_returned_when_ready(self):
+        """A delayed item is returned once its earliest_run has passed."""
+        q = MultiQueue([NORMAL_PRIORITY])
+        soon = _make_item("soon", earliest_run=time.time() + 0.05)
+        q.put(soon, NORMAL_PRIORITY)
+
+        start = time.time()
+        item = q.get()
+        elapsed = time.time() - start
+
+        assert item.value == "soon"
+        assert elapsed >= 0.04  # Had to wait for the delay
+
+    def test_delayed_does_not_block_higher_priority(self):
+        """Higher-priority items run while delayed low-priority waits."""
+        q = MultiQueue([HIGH_PRIORITY, LOW_PRIORITY])
+        delayed = _make_item("delayed", earliest_run=time.time() + 60)
+        urgent = _make_item("urgent", earliest_run=0)
+
+        q.put(delayed, LOW_PRIORITY)
+        q.put(urgent, HIGH_PRIORITY)
+
+        item = q.get()
+        assert item.value == "urgent"
+
+    def test_no_earliest_run_attribute_treated_as_ready(self):
+        """Items without earliest_run are treated as immediately ready."""
+        q = MultiQueue([NORMAL_PRIORITY])
+        q.put("plain-string", NORMAL_PRIORITY)
+        item = q.get()
+        assert item == "plain-string"

--- a/tests/sync/test_task.py
+++ b/tests/sync/test_task.py
@@ -200,3 +200,27 @@ class TestTaskRun:
         t = NoRunTask()
         with pytest.raises(NotImplementedError):
             t.run(None)
+
+
+class TestTaskDelay:
+    """Tests for Task delay / earliest_run."""
+
+    def test_default_delay_zero(self):
+        """Tasks default to delay=0 with earliest_run=0."""
+        t = SimpleTask(name="test")
+        assert t.delay == 0
+        assert t.earliest_run == 0
+
+    def test_delay_sets_earliest_run(self):
+        """A positive delay sets earliest_run in the future."""
+        before = time.time()
+        t = SimpleTask(name="test", delay=10)
+        after = time.time()
+        assert t.delay == 10
+        assert before + 10 <= t.earliest_run <= after + 10
+
+    def test_delay_excluded_from_equality(self):
+        """Delay does not affect equality."""
+        t1 = SimpleTask(name="test", delay=0)
+        t2 = SimpleTask(name="test", delay=30)
+        assert t1 == t2

--- a/tests/sync/test_task.py
+++ b/tests/sync/test_task.py
@@ -13,214 +13,58 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""Tests for base Task class and dataclass behavior."""
+"""Tests for task equality — non-identity fields excluded from comparison."""
 
-import pytest
-from dataclasses import dataclass
-import threading
-import time
-
-from hubtty.sync.task import Task
-from hubtty.sync.constants import NORMAL_PRIORITY, HIGH_PRIORITY
-
-
-@dataclass
-class SimpleTask(Task):
-    """Simple task with one field for testing."""
-
-    name: str
-
-    def run(self, sync):
-        pass
-
-
-@dataclass
-class MultiFieldTask(Task):
-    """Task with multiple fields for testing."""
-
-    field1: str
-    field2: int
-
-    def run(self, sync):
-        pass
+from hubtty.sync.tasks.pull_request import (
+    SyncPullRequestTask,
+    SyncPullRequestChecksTask,
+)
+from hubtty.sync.tasks.repository_check import CheckCommitsTask
 
 
 class TestTaskEquality:
-    """Tests for Task equality comparison."""
+    """Non-identity fields (compare=False) must not affect equality."""
 
-    def test_same_class_same_fields_equal(self):
-        """Tasks with same class and fields are equal."""
-        t1 = SimpleTask(name="test")
-        t2 = SimpleTask(name="test")
+    def test_sync_pr_checks_task_equal_ignores_attempt(self):
+        """SyncPullRequestChecksTask with different attempt values are equal."""
+        t1 = SyncPullRequestChecksTask(
+            pr_id='owner/repo/pulls/1', repository_name='owner/repo', attempt=0
+        )
+        t2 = SyncPullRequestChecksTask(
+            pr_id='owner/repo/pulls/1', repository_name='owner/repo', attempt=12
+        )
         assert t1 == t2
 
-    def test_same_class_different_fields_not_equal(self):
-        """Tasks with different field values are not equal."""
-        t1 = SimpleTask(name="test1")
-        t2 = SimpleTask(name="test2")
+    def test_sync_pr_checks_task_different_pr_not_equal(self):
+        """SyncPullRequestChecksTask with different pr_id are not equal."""
+        t1 = SyncPullRequestChecksTask(
+            pr_id='owner/repo/pulls/1', repository_name='owner/repo', attempt=0
+        )
+        t2 = SyncPullRequestChecksTask(
+            pr_id='owner/repo/pulls/2', repository_name='owner/repo', attempt=0
+        )
         assert t1 != t2
 
-    def test_different_class_not_equal(self):
-        """Tasks of different classes are not equal."""
-        t1 = SimpleTask(name="test")
-        t2 = MultiFieldTask(field1="test", field2=1)
+    def test_sync_pr_task_equal_ignores_force_fetch(self):
+        """SyncPullRequestTask with different force_fetch values are equal."""
+        t1 = SyncPullRequestTask(pr_id='owner/repo/pulls/1', force_fetch=False)
+        t2 = SyncPullRequestTask(pr_id='owner/repo/pulls/1', force_fetch=True)
+        assert t1 == t2
+
+    def test_sync_pr_task_different_pr_not_equal(self):
+        """SyncPullRequestTask with different pr_id are not equal."""
+        t1 = SyncPullRequestTask(pr_id='owner/repo/pulls/1')
+        t2 = SyncPullRequestTask(pr_id='owner/repo/pulls/2')
         assert t1 != t2
 
-    def test_priority_excluded_from_equality(self):
-        """Priority does not affect equality."""
-        t1 = SimpleTask(name="test", priority=HIGH_PRIORITY)
-        t2 = SimpleTask(name="test", priority=NORMAL_PRIORITY)
+    def test_check_commits_task_equal_ignores_force_fetch(self):
+        """CheckCommitsTask with different force_fetch values are equal."""
+        t1 = CheckCommitsTask(repository_key=42, force_fetch=False)
+        t2 = CheckCommitsTask(repository_key=42, force_fetch=True)
         assert t1 == t2
 
-    def test_multi_field_equality(self):
-        """Multi-field tasks compare all fields."""
-        t1 = MultiFieldTask(field1="a", field2=1)
-        t2 = MultiFieldTask(field1="a", field2=1)
-        t3 = MultiFieldTask(field1="a", field2=2)
-
-        assert t1 == t2
-        assert t1 != t3
-
-
-class TestTaskRepr:
-    """Tests for Task repr."""
-
-    def test_repr_includes_fields(self):
-        """repr includes field values."""
-        t = SimpleTask(name="test")
-        r = repr(t)
-        assert "name='test'" in r
-        assert "SimpleTask" in r
-
-    def test_repr_excludes_priority(self):
-        """repr does not include priority."""
-        t = SimpleTask(name="test", priority=HIGH_PRIORITY)
-        r = repr(t)
-        assert "priority" not in r
-
-    def test_repr_multi_field(self):
-        """repr includes all task fields."""
-        t = MultiFieldTask(field1="abc", field2=42)
-        r = repr(t)
-        assert "field1='abc'" in r
-        assert "field2=42" in r
-
-
-class TestTaskCompletion:
-    """Tests for Task completion handling."""
-
-    def test_initial_state(self):
-        """Task starts with succeeded=None."""
-        t = SimpleTask(name="test")
-        assert t.succeeded is None
-
-    def test_complete_success(self):
-        """complete(True) sets succeeded=True."""
-        t = SimpleTask(name="test")
-        t.complete(True)
-        assert t.succeeded is True
-
-    def test_complete_failure(self):
-        """complete(False) sets succeeded=False."""
-        t = SimpleTask(name="test")
-        t.complete(False)
-        assert t.succeeded is False
-
-    def test_wait_returns_after_complete(self):
-        """wait() returns after complete() is called."""
-        t = SimpleTask(name="test")
-
-        def complete_task():
-            time.sleep(0.05)
-            t.complete(True)
-
-        thread = threading.Thread(target=complete_task)
-        thread.start()
-
-        result = t.wait(timeout=1.0)
-        thread.join()
-
-        assert result is True
-
-    def test_wait_timeout(self):
-        """wait() respects timeout."""
-        t = SimpleTask(name="test")
-        start = time.time()
-        result = t.wait(timeout=0.05)
-        elapsed = time.time() - start
-
-        assert result is None  # Not completed yet
-        assert elapsed < 0.2  # Didn't wait forever
-
-
-class TestTaskLogger:
-    """Tests for Task logger."""
-
-    def test_has_logger(self):
-        """Task has a logger."""
-        t = SimpleTask(name="test")
-        assert t.log is not None
-        assert t.log.name == 'hubtty.sync'
-
-
-class TestTaskLists:
-    """Tests for Task task and result lists."""
-
-    def test_tasks_list_empty(self):
-        """Task starts with empty tasks list."""
-        t = SimpleTask(name="test")
-        assert t.tasks == []
-
-    def test_results_list_empty(self):
-        """Task starts with empty results list."""
-        t = SimpleTask(name="test")
-        assert t.results == []
-
-    def test_tasks_list_independent(self):
-        """Each task has its own tasks list."""
-        t1 = SimpleTask(name="test1")
-        t2 = SimpleTask(name="test2")
-
-        t1.tasks.append("subtask")
-        assert len(t1.tasks) == 1
-        assert len(t2.tasks) == 0
-
-
-class TestTaskRun:
-    """Tests for Task run method."""
-
-    def test_base_task_run_raises(self):
-        """Base Task.run() raises NotImplementedError."""
-        # Can't instantiate Task directly since it's abstract
-        # but we can test a task that doesn't override run
-        @dataclass
-        class NoRunTask(Task):
-            pass
-
-        t = NoRunTask()
-        with pytest.raises(NotImplementedError):
-            t.run(None)
-
-
-class TestTaskDelay:
-    """Tests for Task delay / earliest_run."""
-
-    def test_default_delay_zero(self):
-        """Tasks default to delay=0 with earliest_run=0."""
-        t = SimpleTask(name="test")
-        assert t.delay == 0
-        assert t.earliest_run == 0
-
-    def test_delay_sets_earliest_run(self):
-        """A positive delay sets earliest_run in the future."""
-        before = time.time()
-        t = SimpleTask(name="test", delay=10)
-        after = time.time()
-        assert t.delay == 10
-        assert before + 10 <= t.earliest_run <= after + 10
-
-    def test_delay_excluded_from_equality(self):
-        """Delay does not affect equality."""
-        t1 = SimpleTask(name="test", delay=0)
-        t2 = SimpleTask(name="test", delay=30)
-        assert t1 == t2
+    def test_check_commits_task_different_key_not_equal(self):
+        """CheckCommitsTask with different repository_key are not equal."""
+        t1 = CheckCommitsTask(repository_key=42)
+        t2 = CheckCommitsTask(repository_key=99)
+        assert t1 != t2


### PR DESCRIPTION
This adds a lightweight SyncPullRequestChecksTask that re-fetches only CI checks for a PR's last commit, re-submitting itself with exponential back-off.

A new `ignore-pending-checks` config option lets users skip status contexts like tide that stay pending indefinitely.