### PR TITLE
Fix MultiQueue dedup to check all priorities and incomplete list

### DIFF
--- a/hubtty/sync/queue.py
+++ b/hubtty/sync/queue.py
@@ -52,19 +52,39 @@ class MultiQueue:
     def put(self, item: T, priority: int) -> bool:
         """Add an item to the queue at the given priority.
 
+        Deduplication checks all priority levels and the incomplete
+        (currently running) list.  If the item already exists at a
+        lower-importance priority (higher numeric value), it is promoted
+        to the requested priority.
+
         Args:
             item: The item to add.
             priority: The priority level for this item.
 
         Returns:
-            True if the item was added, False if it was already in the queue.
+            True if the item was added (or promoted), False if it was
+            already present at the same or higher priority, or is
+            currently running.
         """
         with self.condition:
-            if item not in self.queues[priority]:
-                self.queues[priority].append(item)
-                self.condition.notify()
-                return True
-            return False
+            # Already running — nothing to do
+            if item in self.incomplete:
+                return False
+            # Check all priority levels
+            for pri, q in self.queues.items():
+                if item in q:
+                    if pri > priority:
+                        # Existing copy at lower importance — promote
+                        q.remove(item)
+                        self.queues[priority].append(item)
+                        self.condition.notify()
+                        return True
+                    # Same or higher importance already queued
+                    return False
+            # Not found anywhere — add it
+            self.queues[priority].append(item)
+            self.condition.notify()
+            return True
 
     def get(self) -> T:
         """Remove and return the highest-priority item.

--- a/tests/sync/test_queue.py
+++ b/tests/sync/test_queue.py
@@ -63,12 +63,49 @@ class TestMultiQueueDuplicates:
         assert q.put("item", HIGH_PRIORITY) is False
         assert q.qsize() == 1
 
-    def test_same_item_different_priority_both_added(self):
-        """Same item at different priorities is allowed."""
+    def test_cross_priority_rejects_lower_priority(self):
+        """Item already at higher priority rejects lower-priority duplicate."""
         q = MultiQueue([HIGH_PRIORITY, NORMAL_PRIORITY])
         assert q.put("item", HIGH_PRIORITY) is True
-        assert q.put("item", NORMAL_PRIORITY) is True
+        assert q.put("item", NORMAL_PRIORITY) is False
+        assert q.qsize() == 1
+
+    def test_cross_priority_promotes_to_higher_priority(self):
+        """Item at lower priority is promoted when submitted at higher priority."""
+        q = MultiQueue([HIGH_PRIORITY, NORMAL_PRIORITY, LOW_PRIORITY])
+        q.put("other", NORMAL_PRIORITY)
+        q.put("item", LOW_PRIORITY)
         assert q.qsize() == 2
+
+        # Promote from LOW to HIGH
+        assert q.put("item", HIGH_PRIORITY) is True
+        assert q.qsize() == 2  # no new entry, just moved
+
+        # Should come out first (HIGH before NORMAL)
+        assert q.get() == "item"
+
+    def test_incomplete_rejects_duplicate(self):
+        """Item currently running (in incomplete) rejects duplicate."""
+        q = MultiQueue([NORMAL_PRIORITY])
+        q.put("item", NORMAL_PRIORITY)
+        q.get()  # moves to incomplete
+        assert q.qsize() == 1  # still in incomplete
+
+        assert q.put("item", NORMAL_PRIORITY) is False
+        assert q.qsize() == 1
+
+    def test_promote_preserves_fifo(self):
+        """Promoted item appends at end of target priority deque."""
+        q = MultiQueue([HIGH_PRIORITY, LOW_PRIORITY])
+        q.put("first", HIGH_PRIORITY)
+        q.put("promoted", LOW_PRIORITY)
+
+        # Promote to HIGH — should go after "first"
+        assert q.put("promoted", HIGH_PRIORITY) is True
+
+        assert q.get() == "first"
+        q.complete("first")
+        assert q.get() == "promoted"
 
 
 class TestMultiQueueSize:


### PR DESCRIPTION
MultiQueue.put() only checked the target priority's deque for duplicates. This allowed the same task to be queued at multiple priority levels (e.g. a SyncPullRequestTask submitted at HIGH from the UI and at LOW from periodic sync), and also allowed re-queuing a task that was already running (in the incomplete list).

Now put() checks:
- The incomplete list first: if the task is already running, reject it.
- All priority queues: if found at a lower-importance priority (higher numeric value), promote it to the requested priority. If found at the same or higher importance, reject as duplicate.