### PR TITLE
Add a sync task viewer

### DIFF
--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -64,6 +64,50 @@ Press the F1 key anywhere to get help.  Your terminal emulator may require you t
 """ % config.CONFIG_PATH
 
 
+class SyncTasksDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
+    """Live-updating dialog showing the sync task queue."""
+
+    signals = ['close']
+    PRIORITY_LABELS = {0: 'high', 1: 'normal', 2: 'low'}
+
+    def __init__(self, app):
+        self.app = app
+        self.text_widget = urwid.Text('')
+        ok_button = mywid.FixedButton('OK')
+        urwid.connect_signal(ok_button, 'click',
+                             lambda button: self._emit('close'))
+        rows = [
+            self.text_widget,
+            urwid.Divider(),
+            urwid.Columns([('pack', ok_button)]),
+        ]
+        listbox = urwid.ListBox(rows)
+        super().__init__(urwid.LineBox(listbox, 'Sync Tasks'))
+        self.refresh()
+
+    def refresh(self):
+        running, queued = self.app.sync.queue.snapshot()
+        total = len(running) + sum(len(tasks) for tasks in queued.values())
+        lines = ['Total tasks: %d' % total, '']
+        if running:
+            lines.append('\N{BLACK RIGHT-POINTING POINTER} Running:')
+            for task in running:
+                lines.append('  %s' % repr(task))
+        else:
+            lines.append('\N{BLACK RIGHT-POINTING POINTER} Running: (none)')
+        for pri in sorted(queued.keys()):
+            tasks = queued[pri]
+            label = self.PRIORITY_LABELS.get(pri, str(pri))
+            lines.append('')
+            if tasks:
+                lines.append('Queued (%s):' % label)
+                for task in tasks:
+                    lines.append('  %s' % repr(task))
+            else:
+                lines.append('Queued (%s): (none)' % label)
+        self.text_widget.set_text('\n'.join(lines))
+
+
 class ClickableText(urwid.WidgetWrap):
     """A text widget that triggers a callback on mouse click."""
 
@@ -492,6 +536,12 @@ class App:
         if invalidate:
             self.updateStatusQueries()
         self.status.refresh()
+        # Refresh live popups (e.g. sync task viewer)
+        body = self.frame.body
+        if isinstance(body, urwid.Overlay):
+            top = body.contents[1][0]
+            if hasattr(top, 'refresh'):
+                top.refresh()
 
     def updateStatusQueries(self):
         with self.db.getSession() as session:
@@ -728,33 +778,10 @@ class App:
         self.clearInputBuffer()
 
     def showSyncTasks(self):
-        PRIORITY_LABELS = {0: 'high', 1: 'normal', 2: 'low'}
-        running, queued = self.sync.queue.snapshot()
-        total = len(running) + sum(len(tasks) for tasks in queued.values())
-        lines = []
-        lines.append('Total tasks: %d' % total)
-        lines.append('')
-        if running:
-            lines.append('\N{BLACK RIGHT-POINTING POINTER} Running:')
-            for task in running:
-                lines.append('  %s' % repr(task))
-        else:
-            lines.append('\N{BLACK RIGHT-POINTING POINTER} Running: (none)')
-        for pri in sorted(queued.keys()):
-            tasks = queued[pri]
-            label = PRIORITY_LABELS.get(pri, str(pri))
-            lines.append('')
-            if tasks:
-                lines.append('Queued (%s):' % label)
-                for task in tasks:
-                    lines.append('  %s' % repr(task))
-            else:
-                lines.append('Queued (%s): (none)' % label)
-        text = '\n'.join(lines)
-        dialog = mywid.MessageDialog('Sync Tasks', text)
+        dialog = SyncTasksDialog(self)
         urwid.connect_signal(dialog, 'close',
             lambda button: self.backScreen())
-        self.popup(dialog, min_width=76, min_height=min(len(lines) + 4, 40))
+        self.popup(dialog, min_width=76, min_height=40)
 
     def openURL(self, url):
         self.log.debug("Open URL %s", url)

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -63,6 +63,21 @@ Press the F1 key anywhere to get help.  Your terminal emulator may require you t
 
 """ % config.CONFIG_PATH
 
+
+class ClickableText(urwid.WidgetWrap):
+    """A text widget that triggers a callback on mouse click."""
+
+    def __init__(self, text_widget, callback):
+        super().__init__(text_widget)
+        self.callback = callback
+
+    def mouse_event(self, size, event, button, col, row, focus):
+        if event == 'mouse release' and button == 1:
+            self.callback()
+            return True
+        return False
+
+
 class StatusHeader(urwid.WidgetWrap):
     def __init__(self, app):
         super().__init__(urwid.Columns([]))
@@ -70,7 +85,8 @@ class StatusHeader(urwid.WidgetWrap):
         self.title_widget = urwid.Text('Start')
         self.error_widget = urwid.Text('')
         self.offline_widget = urwid.Text('')
-        self.sync_widget = urwid.Text('Sync: 0')
+        self.sync_text = urwid.Text('Sync: 0')
+        self.sync_widget = ClickableText(self.sync_text, lambda: app.showSyncTasks())
         self.held_widget = urwid.Text('')
         self._w.contents.append((self.title_widget, ('pack', None, False)))
         self._w.contents.append((urwid.Text(''), ('weight', 1, False)))
@@ -134,7 +150,7 @@ class StatusHeader(urwid.WidgetWrap):
                 self.offline_widget.set_text('')
         if self._sync != self.sync:
             self._sync = self.sync
-            self.sync_widget.set_text(' Sync: %i' % self._sync)
+            self.sync_text.set_text(' Sync: %i' % self._sync)
 
 
 class BreadCrumbBar(urwid.WidgetWrap):

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -685,6 +685,8 @@ class App:
             self.searchDialog('')
         elif keymap.LIST_HELD in commands:
             self.doSearch("is:held")
+        elif keymap.SYNC_TASKS in commands:
+            self.showSyncTasks()
         elif key in self.config.dashboards:
             d = self.config.dashboards[key]
             view = view_pr_list.PullRequestListView(self, d['query'], d['name'],
@@ -708,6 +710,35 @@ class App:
             self.status.update(message=msg)
             return
         self.clearInputBuffer()
+
+    def showSyncTasks(self):
+        PRIORITY_LABELS = {0: 'high', 1: 'normal', 2: 'low'}
+        running, queued = self.sync.queue.snapshot()
+        total = len(running) + sum(len(tasks) for tasks in queued.values())
+        lines = []
+        lines.append('Total tasks: %d' % total)
+        lines.append('')
+        if running:
+            lines.append('\N{BLACK RIGHT-POINTING POINTER} Running:')
+            for task in running:
+                lines.append('  %s' % repr(task))
+        else:
+            lines.append('\N{BLACK RIGHT-POINTING POINTER} Running: (none)')
+        for pri in sorted(queued.keys()):
+            tasks = queued[pri]
+            label = PRIORITY_LABELS.get(pri, str(pri))
+            lines.append('')
+            if tasks:
+                lines.append('Queued (%s):' % label)
+                for task in tasks:
+                    lines.append('  %s' % repr(task))
+            else:
+                lines.append('Queued (%s): (none)' % label)
+        text = '\n'.join(lines)
+        dialog = mywid.MessageDialog('Sync Tasks', text)
+        urwid.connect_signal(dialog, 'close',
+            lambda button: self.backScreen())
+        self.popup(dialog, min_width=76, min_height=min(len(lines) + 4, 40))
 
     def openURL(self, url):
         self.log.debug("Open URL %s", url)

--- a/hubtty/keymap.py
+++ b/hubtty/keymap.py
@@ -39,6 +39,7 @@ QUIT = 'quit'
 PR_SEARCH = 'pull request search'
 REFINE_PR_SEARCH = 'refine pull request search'
 LIST_HELD = 'list held pull requests'
+SYNC_TASKS = 'sync tasks'
 # Pull requests screen:
 TOGGLE_REVIEWED = 'toggle reviewed'
 TOGGLE_HIDDEN = 'toggle hidden'
@@ -106,6 +107,7 @@ DEFAULT_KEYMAP = {
     PR_SEARCH: 'ctrl o',
     REFINE_PR_SEARCH: 'meta o',
     LIST_HELD: 'f12',
+    SYNC_TASKS: 'ctrl t',
 
     TOGGLE_REVIEWED: 'v',
     TOGGLE_HIDDEN: 'k',

--- a/hubtty/mywid.py
+++ b/hubtty/mywid.py
@@ -30,6 +30,8 @@ GLOBAL_HELP = (
      "Search for pull requests"),
     (keymap.LIST_HELD,
      "List held pull requests"),
+    (keymap.SYNC_TASKS,
+     "Show sync task queue"),
     (keymap.KILL,
      "Kill to end of line (editing)"),
     (keymap.YANK,

--- a/hubtty/sync/queue.py
+++ b/hubtty/sync/queue.py
@@ -137,6 +137,19 @@ class MultiQueue:
                     results.append(item)
         return results
 
+    def snapshot(self):
+        """Return a snapshot of running and queued tasks, grouped by priority.
+
+        Returns:
+            A tuple of (running, queued) where running is a list of
+            currently executing tasks and queued is a dict mapping
+            priority level to a list of waiting tasks.
+        """
+        with self.condition:
+            running = list(self.incomplete)
+            queued = {pri: list(q) for pri, q in self.queues.items()}
+        return running, queued
+
     def complete(self, item: T) -> None:
         """Mark an item as complete, removing it from the incomplete list.
 


### PR DESCRIPTION
Binds to Ctrl+t by default, shows the currently active sync task, and the queued ones, sorted by priority.