### PR TITLE
Handle skipped and cancelled check run conclusions

### DIFF
--- a/hubtty/palette.py
+++ b/hubtty/palette.py
@@ -77,6 +77,8 @@ DEFAULT_PALETTE={
     'check-success': ['light green', ''],
     'check-failure': ['light red', ''],
     'check-pending': ['dark magenta', ''],
+    'check-skipped': ['dark gray', ''],
+    'check-cancelled': ['dark gray', ''],
     'state-draft': ['yellow', ''],
     # repository list
     'unreviewed-repository': ['white', ''],

--- a/hubtty/sync/tasks/check_helpers.py
+++ b/hubtty/sync/tasks/check_helpers.py
@@ -47,18 +47,24 @@ def check_result_from_check_run(remote_check: Dict[str, Any]) -> Dict[str, Any]:
         check['message'] = 'Job succeeded'
     elif check['state'] == 'failure':
         check['message'] = 'Job failed'
+    elif check['state'] == 'skipped':
+        check['message'] = 'Job skipped'
+    elif check['state'] == 'cancelled':
+        check['message'] = 'Job cancelled'
     else:
         check['message'] = 'Job triggered'
 
     started = remote_check.get('started_at')
     if started:
-        check['started'] = started
         check['created'] = started
         check['updated'] = started
+        if check['state'] not in ('skipped', 'cancelled'):
+            check['started'] = started
     finished = remote_check.get('completed_at')
     if finished:
-        check['finished'] = finished
         check['updated'] = finished
+        if check['state'] not in ('skipped', 'cancelled'):
+            check['finished'] = finished
 
     return check
 

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -878,7 +878,7 @@ class PullRequestView(urwid.WidgetWrap):
             color = 'check-%s' % check.state
             result = (color, check.message[:39] + (check.message[39:] and '…'))
             line = [self._add_link(check.name, check.url), result]
-            if check.finished and check.started:
+            if check.finished and check.started and check.state not in ('skipped', 'cancelled'):
                 line.append(' in %s' % (check.finished-check.started))
             line.append('\n')
             text.append(line)

--- a/tests/sync/test_check_helpers.py
+++ b/tests/sync/test_check_helpers.py
@@ -116,6 +116,42 @@ class TestCheckResultFromCheckRun:
         assert result['created'] == '2024-06-01T12:00:00Z'
         assert result['updated'] == '2024-06-01T12:00:00Z'
 
+    def test_completed_skipped(self):
+        """Completed check run with skipped conclusion."""
+        remote = {
+            'name': 'semver-label',
+            'html_url': 'https://example.com/run/3',
+            'status': 'completed',
+            'conclusion': 'skipped',
+            'started_at': '2024-01-01T10:00:00Z',
+            'completed_at': '2024-01-01T10:00:01Z',
+        }
+        result = check_result_from_check_run(remote)
+        assert result['state'] == 'skipped'
+        assert result['message'] == 'Job skipped'
+        assert 'started' not in result
+        assert 'finished' not in result
+        assert result['created'] == '2024-01-01T10:00:00Z'
+        assert result['updated'] == '2024-01-01T10:00:01Z'
+
+    def test_completed_cancelled(self):
+        """Completed check run with cancelled conclusion."""
+        remote = {
+            'name': 'ci/deploy',
+            'html_url': 'https://example.com/run/4',
+            'status': 'completed',
+            'conclusion': 'cancelled',
+            'started_at': '2024-01-01T10:00:00Z',
+            'completed_at': '2024-01-01T10:02:00Z',
+        }
+        result = check_result_from_check_run(remote)
+        assert result['state'] == 'cancelled'
+        assert result['message'] == 'Job cancelled'
+        assert 'started' not in result
+        assert 'finished' not in result
+        assert result['created'] == '2024-01-01T10:00:00Z'
+        assert result['updated'] == '2024-01-01T10:02:00Z'
+
     def test_completed_at_overrides_updated(self):
         """completed_at overrides updated field set by started_at."""
         remote = {


### PR DESCRIPTION
Add skipped/cancelled states to check_result_from_check_run so that GitHub Actions jobs with these conclusions are recognised.  Skipped and cancelled runs intentionally omit started/finished timestamps to avoid showing misleading durations in the PR view.