### PR TITLE
Fix check-runs pagination losing all but last page

### DIFF
--- a/hubtty/sync/http.py
+++ b/hubtty/sync/http.py
@@ -330,9 +330,13 @@ class HTTPClient:
             # Process successful response
             if r.status_code == 200:
                 result = json.loads(r.text)
-                # Search queries store results under the 'items' key
+                # Unwrap dict-wrapped paginated responses so that
+                # results from multiple pages are correctly merged
+                # into a single flat list.
                 if isinstance(result, dict) and 'items' in result:
                     result = result.get('items', [])
+                elif isinstance(result, dict) and 'check_runs' in result:
+                    result = result.get('check_runs', [])
                 if isinstance(ret, list):
                     ret.extend(result)
                 else:

--- a/hubtty/sync/tasks/check_helpers.py
+++ b/hubtty/sync/tasks/check_helpers.py
@@ -159,11 +159,11 @@ def fetch_checks(sync: 'Sync', repository_name: str,
             checks.append(check_result_from_status(check))
 
     remote_commit_check_runs = sync.get(
-        f'repos/{repository_name}/commits/{commit_sha}/check-runs',
+        f'repos/{repository_name}/commits/{commit_sha}/check-runs?per_page=100',
         use_etag=use_etag,
     )
     if remote_commit_check_runs is not None:
-        for check in remote_commit_check_runs['check_runs']:
+        for check in remote_commit_check_runs:
             checks.append(check_result_from_check_run(check))
 
     return checks

--- a/tests/sync/test_check_helpers.py
+++ b/tests/sync/test_check_helpers.py
@@ -320,13 +320,13 @@ class TestFetchChecks:
                  'created_at': '2024-01-01T10:00:00Z',
                  'updated_at': '2024-01-01T10:05:00Z'},
             ]},
-            # check runs response
-            {'check_runs': [
+            # check runs response (unwrapped by get())
+            [
                 {'name': 'ci/check', 'html_url': 'http://y',
                  'status': 'completed', 'conclusion': 'failure',
                  'started_at': '2024-01-01T10:00:00Z',
                  'completed_at': '2024-01-01T10:03:00Z'},
-            ]},
+            ],
         ]
         result = fetch_checks(sync, 'owner/repo', 'abc123')
         assert len(result) == 2
@@ -340,14 +340,15 @@ class TestFetchChecks:
         sync.get.assert_any_call(
             'repos/owner/repo/commits/abc123/status', use_etag=True)
         sync.get.assert_any_call(
-            'repos/owner/repo/commits/abc123/check-runs', use_etag=True)
+            'repos/owner/repo/commits/abc123/check-runs?per_page=100',
+            use_etag=True)
 
     def test_empty_statuses_and_check_runs(self):
         """Returns empty list when no checks exist."""
         sync = Mock()
         sync.get.side_effect = [
             {'statuses': []},
-            {'check_runs': []},
+            [],  # check runs (unwrapped by get())
         ]
         result = fetch_checks(sync, 'owner/repo', 'abc123')
         assert result == []
@@ -362,7 +363,7 @@ class TestFetchChecks:
                  'created_at': '2024-01-01T10:00:00Z',
                  'updated_at': '2024-01-01T10:00:00Z'},
             ]},
-            {'check_runs': []},
+            [],  # check runs (unwrapped by get())
         ]
         result = fetch_checks(sync, 'owner/repo', 'abc123')
         assert len(result) == 1

--- a/tests/sync/test_pull_request.py
+++ b/tests/sync/test_pull_request.py
@@ -113,7 +113,7 @@ def _setup_sync(mock_sync, remote_pr, remote_commits, commit_details,
         if '/status' in path:
             return {'statuses': []}
         if '/check-runs' in path:
-            return {'check_runs': []}
+            return []  # check runs (unwrapped by get())
         return {}
 
     mock_sync.get = Mock(side_effect=get_side_effect)


### PR DESCRIPTION
The get() pagination logic only merged list responses correctly. Dict-wrapped paginated responses like check-runs ({"check_runs": [...]}) were silently overwritten on each page, keeping only the last page's data. This caused PRs with many CI checks to show only a handful.

- Unwrap 'check_runs' key in get() pagination (like 'items' for search)
- Add per_page=100 to check-runs URL (matches all other endpoints)
- Update fetch_checks() to iterate the now-flat list from get()
- Update tests to match new return format