### PR TITLE
Catch SearchSyntaxError in dashboard and repository views

### DIFF
--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -755,10 +755,13 @@ class App:
             self.showSyncTasks()
         elif key in self.config.dashboards:
             d = self.config.dashboards[key]
-            view = view_pr_list.PullRequestListView(self, d['query'], d['name'],
-                                                    sort_by=d.get('sort-by'),
-                                                    reverse=d.get('reverse'))
-            self.changeScreen(view)
+            try:
+                view = view_pr_list.PullRequestListView(self, d['query'], d['name'],
+                                                        sort_by=d.get('sort-by'),
+                                                        reverse=d.get('reverse'))
+                self.changeScreen(view)
+            except hubtty.search.SearchSyntaxError as e:
+                self.error(e.message)
         elif keymap.FURTHER_INPUT in commands:
             self.input_buffer.append(key)
             msg = ''.join(self.input_buffer)

--- a/hubtty/view/repository_list.py
+++ b/hubtty/view/repository_list.py
@@ -16,6 +16,7 @@
 import logging
 import urwid
 
+import hubtty.search
 from hubtty import keymap
 from hubtty import mywid
 from hubtty import sync
@@ -360,10 +361,13 @@ class RepositoryListView(urwid.WidgetWrap, mywid.Searchable):
 
     def onSelect(self, button, data):
         repository_key, repository_name = data
-        self.app.changeScreen(view_pr_list.PullRequestListView(
-                self.app,
-                f"_repository_key:{repository_key} {self.app.config.repository_pr_list_query}",
-                repository_name, repository_key=repository_key, unreviewed=True))
+        try:
+            self.app.changeScreen(view_pr_list.PullRequestListView(
+                    self.app,
+                    f"_repository_key:{repository_key} {self.app.config.repository_pr_list_query}",
+                    repository_name, repository_key=repository_key, unreviewed=True))
+        except hubtty.search.SearchSyntaxError as e:
+            self.app.error(e.message)
 
     def onSelectTopic(self, button, data):
         topic_key = data[0]


### PR DESCRIPTION
Invalid search syntax in dashboard queries or repository PR list views caused an unhandled exception that crashed the TUI. Wrap PullRequestListView construction in try/except blocks to catch SearchSyntaxError and display an error dialog instead, matching the existing pattern in doSearch().

Fixes #119.