### PR TITLE
Add key binding to toggle between unified and side-by-side diff

### DIFF
--- a/hubtty/keymap.py
+++ b/hubtty/keymap.py
@@ -82,6 +82,7 @@ PREV_SELECTABLE = 'prev selectable'
 NEXT_COMMIT = 'next commit'
 PREV_COMMIT = 'prev commit'
 INTERACTIVE_SEARCH = 'interactive search'
+TOGGLE_DIFF_VIEW = 'toggle diff view'
 # Special:
 FURTHER_INPUT = 'further input'
 
@@ -150,6 +151,7 @@ DEFAULT_KEYMAP = {
     NEXT_COMMIT: '>',
     PREV_COMMIT: '<',
     INTERACTIVE_SEARCH: 'ctrl s',
+    TOGGLE_DIFF_VIEW: 'f2',
 }
 
 # Hi vi users!  Add more things here!  This overrides the default
@@ -172,6 +174,7 @@ VI_KEYMAP = {
     TOGGLE_HIDDEN: [['t', 'h']],
     TOGGLE_LIST_REVIEWED: [['t', 'R']],
     TOGGLE_LIST_SUBSCRIBED: 'L',
+    TOGGLE_DIFF_VIEW: [['t', 'd']],
 
     EDIT_PULL_REQUEST: 'ctrl e',
 }

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -107,6 +107,8 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
              "Diff the previous commit"),
             (keymap.INTERACTIVE_SEARCH,
              "Interactive search"),
+            (keymap.TOGGLE_DIFF_VIEW,
+             "Toggle between unified and side-by-side diff"),
             ]
 
     def help(self):
@@ -420,6 +422,9 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
         if keymap.INTERACTIVE_SEARCH in commands:
             self.searchStart()
             return None
+        if keymap.TOGGLE_DIFF_VIEW in commands:
+            self.toggleDiffView()
+            return None
         if key in self.app.config.reviewkeys:
             self.reviewKey(self.app.config.reviewkeys[key])
             return None
@@ -487,6 +492,18 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
         if pr_view:
             pr_view.reviewKey(reviewkey)
         self.app.backScreen()
+
+    def toggleDiffView(self):
+        config = self.app.config
+        if config.diff_view == 'unified':
+            config.diff_view = 'side-by-side'
+            from hubtty.view.side_diff import SideDiffView
+            new_screen = SideDiffView(self.app, self.new_commit_key)
+        else:
+            config.diff_view = 'unified'
+            from hubtty.view.unified_diff import UnifiedDiffView
+            new_screen = UnifiedDiffView(self.app, self.new_commit_key)
+        self.app.changeScreen(new_screen, push=False)
 
     def moveCommit(self, offset):
         commits = []


### PR DESCRIPTION
Add `TOGGLE_DIFF_VIEW` command bound to F2 (default) and t,d (vi keymap) that switches between unified and side-by-side diff views in place without disturbing the screen stack.