### PR TITLE
Fix check retry tasks being silently rejected by queue deduplication

### DIFF
--- a/hubtty/sync/sync.py
+++ b/hubtty/sync/sync.py
@@ -157,6 +157,8 @@ class Sync(HTTPClient):
             task.run(self)
             task.complete(True)
             self.queue.complete(task)
+            if task.followup:
+                self.submitTask(task.followup)
         except (
             requests.ConnectionError,
             OfflineError,

--- a/hubtty/sync/task.py
+++ b/hubtty/sync/task.py
@@ -67,6 +67,7 @@ class Task:
     )
     tasks: List['Task'] = field(default_factory=list, init=False, compare=False, repr=False)
     results: List[Any] = field(default_factory=list, init=False, compare=False, repr=False)
+    followup: Optional['Task'] = field(default=None, init=False, compare=False, repr=False)
 
     def __post_init__(self) -> None:
         """Initialize the logger after dataclass initialization."""

--- a/hubtty/sync/tasks/pull_request.py
+++ b/hubtty/sync/tasks/pull_request.py
@@ -524,13 +524,13 @@ class SyncPullRequestChecksTask(Task):
                     "retrying in %ds",
                     self.pr_id, self.attempt + 1, MAX_CHECK_RETRIES, delay,
                 )
-                sync.submitTask(SyncPullRequestChecksTask(
+                self.followup = SyncPullRequestChecksTask(
                     self.pr_id,
                     self.repository_name,
                     attempt=self.attempt + 1,
                     priority=self.priority,
                     delay=delay,
-                ))
+                )
             else:
                 self.log.warning(
                     "Giving up on pending checks for %s after %d attempts",


### PR DESCRIPTION
SyncPullRequestChecksTask.run() was calling sync.submitTask() to resubmit itself with an incremented attempt counter while the current task was still in the queue's incomplete list. Because the attempt field has compare=False, the new task compared equal to the running one, so MultiQueue.put() rejected it as a duplicate. This meant CI checks were fetched exactly once and never retried.

Add a followup field to the Task base class. Tasks that need to schedule a continuation set self.followup instead of calling submitTask() directly. Sync._run() submits the followup after queue.complete(), when the original task has already left the incomplete list, so deduplication passes naturally.