### PR TITLE
Auto-link GitHub issue/PR references (#N) in comments

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -258,6 +258,29 @@ to an internal Hubtty search for pull requests authored by that user.
              text: "{mention_str}"
              query: "author:{username}"
 
+Built-in Issue References
++++++++++++++++++++++++++
+
+Hubtty automatically links GitHub issue and pull request references in
+comments and descriptions.  Two patterns are recognized:
+
+**#N**
+  Links to issue or pull request N in the current repository.  For
+  example, ``#1234`` in a comment on ``myorg/myrepo`` will link to
+  ``https://github.com/myorg/myrepo/issues/1234``.
+
+**owner/repo#N**
+  Links to issue or pull request N in the specified repository.  For
+  example, ``otherorg/otherrepo#42`` will link to
+  ``https://github.com/otherorg/otherrepo/issues/42``.
+
+GitHub automatically redirects ``/issues/N`` to ``/pull/N`` when the
+reference is a pull request, so these links work for both issues and
+pull requests.
+
+These built-in commentlinks are applied after any user-defined
+commentlinks.
+
 Pull Request List Options
 +++++++++++++++++++++++++
 

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -689,9 +689,18 @@ class App:
         pr = patchset = filename = None
         path = [x for x in result.path.split('/') if x]
         if path:
-            pr = path[0]
+            # Recognise /owner/repo/pull/N paths; anything else
+            # (including /owner/repo/issues/N) is not a local PR
+            # and should be opened in the browser instead.
+            if (len(path) >= 4 and path[2] == 'pull'
+                    and path[3].isdigit()):
+                pr = path[3]
+            else:
+                return None
         else:
             path = [x for x in result.fragment.split('/') if x]
+            if not path:
+                return None
             if path[0] == 'c':
                 path.pop(0)
             while path:

--- a/hubtty/commentlink.py
+++ b/hubtty/commentlink.py
@@ -75,19 +75,25 @@ class CommentLink:
             if 'search' in r:
                 self.replacements.append(SearchReplacement(r['search']))
 
-    def getTestResults(self, app, text):
+    def getTestResults(self, app, text, context=None):
         if self.test_result is None:
             return {}
         ret = collections.OrderedDict()
         for line in text.split('\n'):
             m = self.match.search(line)
             if m:
-                repl = [r.replace(app, m.groupdict()) for r in self.replacements]
-                job = self.test_result.format(**m.groupdict())
+                data = m.groupdict()
+                if context:
+                    data.update(context)
+                try:
+                    repl = [r.replace(app, data) for r in self.replacements]
+                    job = self.test_result.format(**data)
+                except KeyError:
+                    continue
                 ret[job] = repl + ['\n']
         return ret
 
-    def run(self, app, chunks):
+    def run(self, app, chunks, context=None):
         ret = []
         for chunk in chunks:
             if not isinstance(chunk, str):
@@ -105,9 +111,22 @@ class CommentLink:
                     break
                 before = chunk[:m.start()]
                 after = chunk[m.end():]
+                data = m.groupdict()
+                if context:
+                    data.update(context)
+                try:
+                    replacements = [r.replace(app, data)
+                                    for r in self.replacements]
+                except KeyError:
+                    # A replacement references a context variable
+                    # (e.g. {repository}) that isn't available;
+                    # skip this match and keep the original text.
+                    ret.append(chunk[:m.end()])
+                    chunk = after
+                    continue
                 if before:
                     ret.append(before)
-                ret += [r.replace(app, m.groupdict()) for r in self.replacements]
+                ret += replacements
                 chunk = after
         return ret
 

--- a/hubtty/config.py
+++ b/hubtty/config.py
@@ -200,6 +200,22 @@ class Config:
                         dict(link=dict(
                                 text="{url}",
                                 url="{url}"))])))
+        # Cross-repo issue/PR reference: owner/repo#1234
+        self.commentlinks.append(
+            hubtty.commentlink.CommentLink(dict(
+                    match=r"(?<!\w)(?P<cross_repo>[A-Za-z0-9_][A-Za-z0-9_.-]*/[A-Za-z0-9_][A-Za-z0-9_.-]*)#(?P<number>\d+)",
+                    replacements=[
+                        dict(link=dict(
+                                text="{cross_repo}#{number}",
+                                url=self.url + "{cross_repo}/issues/{number}"))])))
+        # Same-repo issue/PR reference: #1234 (uses {repository} from context)
+        self.commentlinks.append(
+            hubtty.commentlink.CommentLink(dict(
+                    match=r"(?<![/\w])#(?P<number>\d+)\b",
+                    replacements=[
+                        dict(link=dict(
+                                text="#{number}",
+                                url=self.url + "{repository}/issues/{number}"))])))
 
         self.repository_pr_list_query = self.config.get('pr-list-query', 'state:open')
 

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -475,8 +475,9 @@ class PullRequestMessageBox(mywid.HyperText):
                 comment_text = ["\n"] + comment_text
             else:
                 comment_text[0] = "\n%s" % comment_text[0]
+        context = {'repository': self.pr_view.repository_name} if hasattr(self.pr_view, 'repository_name') else None
         for commentlink in self.app.config.commentlinks:
-            comment_text = commentlink.run(self.app, comment_text)
+            comment_text = commentlink.run(self.app, comment_text, context)
 
         inline_comments = {}
         for comment in message.comments:
@@ -507,22 +508,24 @@ class PullRequestMessageBox(mywid.HyperText):
                 # location_str
                 rendered_comment = self.md.render(comment)
                 for commentlink in self.app.config.commentlinks:
-                    rendered_comment = commentlink.run(self.app, rendered_comment)
+                    rendered_comment = commentlink.run(self.app, rendered_comment, context)
                 comment_text.extend(rendered_comment)
                 comment_text.append('\n')
 
         self.set_text(text+comment_text)
 
 class PrDescriptionBox(mywid.HyperText):
-    def __init__(self, app, message):
+    def __init__(self, app, message, repository_name=None):
         self.app = app
+        self.repository_name = repository_name
         super().__init__(message)
 
     def set_text(self, text):
         if len(text) == 0:
             text = [text]
+        context = {'repository': self.repository_name} if self.repository_name else None
         for commentlink in self.app.config.commentlinks:
-            text = commentlink.run(self.app, text)
+            text = commentlink.run(self.app, text, context)
         super().set_text(text)
 
 @mouse_scroll_decorator.ScrollByWheel
@@ -741,6 +744,7 @@ class PullRequestView(urwid.WidgetWrap):
             self.status_label.set_text(('pr-data', stat))
             self.permalink_url = str(pr.html_url)
             self.permalink_label.text.set_text(('pr-data', self.permalink_url))
+            self.pr_description.repository_name = self.repository_name
             self.pr_description.set_text(["%s\n\n" % pr.title] + self.md.render(pr.body))
 
             review_states = ['Changes Requested', 'Comment', 'Approved']
@@ -820,7 +824,8 @@ class PullRequestView(urwid.WidgetWrap):
                 if (message.commit == pr.commits[-1] and
                     message.author and message.author.name):
                     for commentlink in self.app.config.commentlinks:
-                        results = commentlink.getTestResults(self.app, message.message)
+                        results = commentlink.getTestResults(self.app, message.message,
+                                                            context={'repository': self.repository_name})
                         if results:
                             result_system = result_systems.get(message.author.name,
                                                                collections.OrderedDict())

--- a/tests/test_commentlink.py
+++ b/tests/test_commentlink.py
@@ -1,0 +1,269 @@
+# Copyright The Hubtty Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Tests for commentlink patterns (issue/PR auto-linking)."""
+
+from unittest.mock import Mock
+
+from hubtty.commentlink import CommentLink
+from hubtty import mywid
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BASE_URL = 'https://github.com/'
+
+SAME_REPO_CONFIG = dict(
+    match=r"(?<![/\w])#(?P<number>\d+)\b",
+    replacements=[
+        dict(link=dict(
+            text="#{number}",
+            url=BASE_URL + "{repository}/issues/{number}"))],
+)
+
+CROSS_REPO_CONFIG = dict(
+    match=r"(?<!\w)(?P<cross_repo>[A-Za-z0-9_][A-Za-z0-9_.-]*/[A-Za-z0-9_][A-Za-z0-9_.-]*)#(?P<number>\d+)",
+    replacements=[
+        dict(link=dict(
+            text="{cross_repo}#{number}",
+            url=BASE_URL + "{cross_repo}/issues/{number}"))],
+)
+
+
+def _mock_app():
+    app = Mock()
+    app.parseInternalURL = Mock(return_value=None)
+    app.openURL = Mock()
+    return app
+
+
+def _link_texts(result):
+    """Extract display texts from run() output, resolving Link objects."""
+    texts = []
+    for item in result:
+        if isinstance(item, mywid.Link):
+            texts.append(item.text)
+        elif isinstance(item, str):
+            texts.append(item)
+    return texts
+
+
+def _link_objects(result):
+    """Return only Link objects from run() output."""
+    return [item for item in result if isinstance(item, mywid.Link)]
+
+
+# ---------------------------------------------------------------------------
+# Same-repo #N pattern
+# ---------------------------------------------------------------------------
+
+class TestSameRepoCommentLink:
+    def test_links_issue_reference_with_context(self):
+        cl = CommentLink(SAME_REPO_CONFIG)
+        app = _mock_app()
+        context = {'repository': 'octocat/Hello-World'}
+        result = cl.run(app, ['See #42 for details'], context)
+
+        texts = _link_texts(result)
+        assert texts == ['See ', '#42', ' for details']
+
+        links = _link_objects(result)
+        assert len(links) == 1
+        assert links[0].text == '#42'
+
+    def test_creates_link_without_context(self):
+        """When context is None, {repository} is missing from data, but
+        it only appears in the URL (evaluated lazily inside a lambda),
+        so the link IS created.  The URL will be broken at click time."""
+        cl = CommentLink(SAME_REPO_CONFIG)
+        app = _mock_app()
+        result = cl.run(app, ['See #42 for details'], None)
+
+        links = _link_objects(result)
+        assert len(links) == 1
+        assert links[0].text == '#42'
+
+    def test_multiple_references(self):
+        cl = CommentLink(SAME_REPO_CONFIG)
+        app = _mock_app()
+        context = {'repository': 'octocat/Hello-World'}
+        result = cl.run(app, ['Fixes #1 and #2'], context)
+
+        links = _link_objects(result)
+        assert len(links) == 2
+        assert links[0].text == '#1'
+        assert links[1].text == '#2'
+
+    def test_no_match_inside_url(self):
+        """The negative lookbehind (?<![/\\w]) should prevent matching
+        #N when preceded by a slash (e.g. inside a URL path)."""
+        cl = CommentLink(SAME_REPO_CONFIG)
+        app = _mock_app()
+        context = {'repository': 'octocat/Hello-World'}
+        result = cl.run(app, ['https://example.com/issues/#99'], context)
+
+        links = _link_objects(result)
+        assert len(links) == 0
+
+    def test_no_match_when_preceded_by_word_char(self):
+        cl = CommentLink(SAME_REPO_CONFIG)
+        app = _mock_app()
+        context = {'repository': 'octocat/Hello-World'}
+        result = cl.run(app, ['foo#99'], context)
+
+        links = _link_objects(result)
+        assert len(links) == 0
+
+    def test_match_at_start_of_string(self):
+        cl = CommentLink(SAME_REPO_CONFIG)
+        app = _mock_app()
+        context = {'repository': 'octocat/Hello-World'}
+        result = cl.run(app, ['#7 is done'], context)
+
+        links = _link_objects(result)
+        assert len(links) == 1
+        assert links[0].text == '#7'
+
+    def test_empty_input(self):
+        cl = CommentLink(SAME_REPO_CONFIG)
+        app = _mock_app()
+        result = cl.run(app, [''], None)
+        assert result == ['']
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo owner/repo#N pattern
+# ---------------------------------------------------------------------------
+
+class TestCrossRepoCommentLink:
+    def test_links_cross_repo_reference(self):
+        cl = CommentLink(CROSS_REPO_CONFIG)
+        app = _mock_app()
+        result = cl.run(app, ['See octocat/Hello-World#42'], None)
+
+        links = _link_objects(result)
+        assert len(links) == 1
+        assert links[0].text == 'octocat/Hello-World#42'
+
+    def test_no_context_needed(self):
+        """Cross-repo pattern doesn't reference {repository}, so it
+        works without context."""
+        cl = CommentLink(CROSS_REPO_CONFIG)
+        app = _mock_app()
+        result = cl.run(app, ['fixes org/repo#10'], None)
+
+        links = _link_objects(result)
+        assert len(links) == 1
+        assert links[0].text == 'org/repo#10'
+
+    def test_repo_with_dots_and_hyphens(self):
+        cl = CommentLink(CROSS_REPO_CONFIG)
+        app = _mock_app()
+        result = cl.run(app, ['see my-org/my.repo#5'], None)
+
+        links = _link_objects(result)
+        assert len(links) == 1
+        assert links[0].text == 'my-org/my.repo#5'
+
+    def test_lookbehind_prevents_mid_word_match(self):
+        r"""The (?<!\w) lookbehind prevents matching a cross-repo ref
+        that starts mid-word, e.g. after an email-like prefix."""
+        cl = CommentLink(CROSS_REPO_CONFIG)
+        app = _mock_app()
+
+        # At position 0 with no preceding char, the lookbehind passes
+        # and the whole prefix is absorbed into the owner name.
+        result = cl.run(app, ['prefixowner/repo#1'], None)
+        links = _link_objects(result)
+        assert len(links) == 1
+        assert links[0].text == 'prefixowner/repo#1'
+
+        # When a word char appears right before a second ref in mid-text
+        # and the first ref has already been consumed, the lookbehind
+        # prevents partial matching.  E.g. 'textowner/repo#1' mid-text
+        # where 'text' is contiguous still absorbs into the owner.
+        # But if the cross-repo ref is separated by a non-word char
+        # (space, punctuation) it matches correctly.
+        result2 = cl.run(app, ['see owner/repo#5 done'], None)
+        links2 = _link_objects(result2)
+        assert len(links2) == 1
+        assert links2[0].text == 'owner/repo#5'
+
+    def test_rejects_leading_dot_in_owner_at_start(self):
+        """When .hidden/repo#1 appears at position 0, the dot is not in
+        [A-Za-z0-9_] so the match can't start there.  But the regex
+        engine advances and matches hidden/repo#1 starting after the dot
+        (since '.' is not a word character, the lookbehind passes)."""
+        cl = CommentLink(CROSS_REPO_CONFIG)
+        app = _mock_app()
+        result = cl.run(app, ['.hidden/repo#1'], None)
+
+        links = _link_objects(result)
+        assert len(links) == 1
+        assert links[0].text == 'hidden/repo#1'
+
+    def test_rejects_dot_only_owner(self):
+        """An owner consisting of only dots can't match because the
+        first character must be [A-Za-z0-9_]."""
+        cl = CommentLink(CROSS_REPO_CONFIG)
+        app = _mock_app()
+        result = cl.run(app, ['  .../repo#1'], None)
+
+        # The regex can match 'repo#1' — wait, there's no '/' before
+        # repo in a way that satisfies the cross_repo group structure.
+        # Actually '../repo#1' can match: '.' skipped, './' — no.
+        # Let's just verify the only match would be 'repo' as owner:
+        # './repo#1' — after '.', '/' is not [A-Za-z0-9_], skip.
+        # Only possible if both owner and repo segments have valid starts.
+        links = _link_objects(result)
+        assert len(links) == 0
+
+    def test_rejects_leading_dot_in_repo(self):
+        cl = CommentLink(CROSS_REPO_CONFIG)
+        app = _mock_app()
+        result = cl.run(app, ['owner/.secret#1'], None)
+
+        links = _link_objects(result)
+        assert len(links) == 0
+
+    def test_multiple_cross_repo_references(self):
+        cl = CommentLink(CROSS_REPO_CONFIG)
+        app = _mock_app()
+        result = cl.run(app, ['a/b#1 and c/d#2'], None)
+
+        links = _link_objects(result)
+        assert len(links) == 2
+        assert links[0].text == 'a/b#1'
+        assert links[1].text == 'c/d#2'
+
+
+# ---------------------------------------------------------------------------
+# Non-string chunk pass-through
+# ---------------------------------------------------------------------------
+
+class TestNonStringChunks:
+    def test_non_string_chunks_passed_through(self):
+        """CommentLink.run() should pass non-string items (e.g. Link
+        widgets) through unchanged."""
+        cl = CommentLink(SAME_REPO_CONFIG)
+        app = _mock_app()
+        widget = mywid.Link('existing', 'link', 'focused-link')
+        result = cl.run(app, [widget, ' and #1'], {'repository': 'o/r'})
+
+        assert result[0] is widget
+        links = _link_objects(result[1:])
+        assert len(links) == 1
+        assert links[0].text == '#1'

--- a/tests/test_parse_internal_url.py
+++ b/tests/test_parse_internal_url.py
@@ -1,0 +1,159 @@
+# Copyright The Hubtty Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Tests for App.parseInternalURL with the new /owner/repo/pull/N format."""
+
+import re
+import types
+
+from unittest.mock import Mock
+
+
+# ---------------------------------------------------------------------------
+# Helpers – build a minimal object that has parseInternalURL bound to it
+# ---------------------------------------------------------------------------
+
+def _make_parser(base_url='https://github.com/'):
+    """Return a lightweight object with parseInternalURL and the
+    attributes it relies on (config.url, trailing_filename_re)."""
+
+    obj = Mock()
+    obj.config.url = base_url
+    obj.trailing_filename_re = re.compile(r'.*(,[a-z]+)')
+
+    # Bind the real implementation from app.py source so we test the
+    # actual logic, not a mock.
+    from hubtty.app import App
+    obj.parseInternalURL = types.MethodType(App.parseInternalURL, obj)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# /owner/repo/pull/N  (path-based)
+# ---------------------------------------------------------------------------
+
+class TestPathBasedURLs:
+    def test_valid_pr_url(self):
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/octocat/Hello-World/pull/123')
+        assert result == ('123', None, None)
+
+    def test_pr_url_with_trailing_slash(self):
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/octocat/Hello-World/pull/123/')
+        assert result == ('123', None, None)
+
+    def test_pr_url_with_extra_path_segments(self):
+        """Extra segments after the PR number are ignored; the important
+        thing is that path[2]=='pull' and path[3] is a digit."""
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/octocat/Hello-World/pull/7/files')
+        assert result == ('7', None, None)
+
+    def test_issue_url_returns_none(self):
+        """Issues are not PRs — should return None so the browser opens."""
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/octocat/Hello-World/issues/42')
+        assert result is None
+
+    def test_repo_root_returns_none(self):
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/octocat/Hello-World')
+        assert result is None
+
+    def test_non_numeric_pr_returns_none(self):
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/octocat/Hello-World/pull/abc')
+        assert result is None
+
+    def test_short_path_returns_none(self):
+        """Paths with fewer than 4 segments and no 'pull' keyword."""
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/octocat')
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# External URLs
+# ---------------------------------------------------------------------------
+
+class TestExternalURLs:
+    def test_different_host_returns_none(self):
+        p = _make_parser()
+        result = p.parseInternalURL('https://example.com/owner/repo/pull/1')
+        assert result is None
+
+    def test_completely_different_url(self):
+        p = _make_parser()
+        result = p.parseInternalURL('https://gitlab.com/foo/bar')
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Fragment-based URLs  (the else branch)
+# ---------------------------------------------------------------------------
+
+class TestFragmentBasedURLs:
+    def test_empty_fragment_returns_none(self):
+        """The new guard: empty fragment should return None, not crash."""
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/#')
+        assert result is None
+
+    def test_empty_fragment_with_slashes_returns_none(self):
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/#///')
+        assert result is None
+
+    def test_fragment_with_pr_number(self):
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/#42')
+        assert result == ('42', None, None)
+
+    def test_fragment_with_c_prefix(self):
+        """Legacy fragment format: #c/pr/patchset"""
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/#c/99/2')
+        assert result == ('99', '2', None)
+
+    def test_fragment_with_filename(self):
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/#c/99/2/src/main.py')
+        assert result == ('99', '2', 'src/main.py')
+
+    def test_bare_base_url_with_no_fragment(self):
+        """Base URL with no path and no fragment → empty path, empty
+        fragment → should return None (guard) or (None, None, None)."""
+        p = _make_parser()
+        result = p.parseInternalURL('https://github.com/')
+        # Empty path AND empty fragment → the guard returns None
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Custom base URL
+# ---------------------------------------------------------------------------
+
+class TestCustomBaseURL:
+    def test_github_enterprise(self):
+        p = _make_parser('https://git.corp.example.com/')
+        result = p.parseInternalURL(
+            'https://git.corp.example.com/team/project/pull/55')
+        assert result == ('55', None, None)
+
+    def test_github_enterprise_issue_returns_none(self):
+        p = _make_parser('https://git.corp.example.com/')
+        result = p.parseInternalURL(
+            'https://git.corp.example.com/team/project/issues/55')
+        assert result is None


### PR DESCRIPTION
Add built-in commentlinks that turn #N and owner/repo#N references into clickable links pointing to the GitHub issues URL. GitHub automatically redirects /issues/N to /pull/N for pull requests.

The same-repo #N pattern uses a new context mechanism: CommentLink.run() and getTestResults() accept an optional context dict that is merged into regex match groups before formatting replacements. The PR view passes the current repository name as context. A KeyError is caught gracefully so commentlinks referencing unavailable context variables are silently skipped.

Also fix parseInternalURL to only recognize /owner/repo/pull/N paths as internal PRs. Previously any URL starting with the server URL was parsed as internal, causing issue links to trigger 'Pull request is not in local database' errors instead of opening in the browser.