### PR TITLE
Add custom-commands: bind keys to run shell commands

### DIFF
--- a/examples/reference-hubtty.yaml
+++ b/examples/reference-hubtty.yaml
@@ -259,6 +259,37 @@ dashboards:
 #     description: 'Request unit tests'
 #     draft: True
 
+# Custom commands allow binding keys to run shell commands with context
+# variable interpolation from the current screen.
+#
+# Available contexts and their variables:
+#   repository-list:   {repository}
+#   pull-request-list: {repository}, {number}, {branch}, {author}, {sha}
+#   pull-request:      {repository}, {number}, {branch}, {author}, {sha},
+#                      {title}, {url}
+#   diff:              {repository}, {sha}
+#
+# If 'context' is omitted, the command is available on all screens
+# (but interpolation will fail if a variable is not available).
+#
+# Variable values are automatically shell-quoted for safety.
+# To pass unquoted values, use command wrappers or scripts.
+# custom-commands:
+#   - key: 'meta 1'
+#     command: 'xdg-open https://github.com/{repository}/pull/{number}'
+#     description: 'Open PR in browser'
+#     context:
+#       - pull-request
+#       - pull-request-list
+#   - key: 'meta 2'
+#     command: 'gh pr checkout {number} --repo {repository}'
+#     description: 'Checkout PR with gh CLI'
+#     context:
+#       - pull-request
+#   - key: 'meta 3'
+#     command: 'notify-send Hubtty {repository}'
+#     description: 'Desktop notification for repository'
+
 # 'size-column' is a set of customize parameters for the 'Size' column
 # on your dashboard.
 # 'type' must be 'graph', 'split-graph' or 'number'. Default is 'graph'.

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -22,6 +22,7 @@ import functools
 import logging
 import os
 import re
+import shlex
 import socket
 import subprocess
 import sys
@@ -47,8 +48,18 @@ from hubtty import requestsexceptions
 from hubtty.view import pull_request_list as view_pr_list
 from hubtty.view import repository_list as view_repository_list
 from hubtty.view import pull_request as view_pr
+from hubtty.view import side_diff as view_side_diff
+from hubtty.view import unified_diff as view_unified_diff
 import hubtty.view
 import hubtty.version
+
+SCREEN_CONTEXT_NAMES = {
+    view_repository_list.RepositoryListView: 'repository-list',
+    view_pr_list.PullRequestListView: 'pull-request-list',
+    view_pr.PullRequestView: 'pull-request',
+    view_side_diff.SideDiffView: 'diff',
+    view_unified_diff.UnifiedDiffView: 'diff',
+}
 
 WELCOME_TEXT = """\
 Welcome to Hubtty!
@@ -425,6 +436,50 @@ class App:
     def isOwnAccount(self, account):
         return account.id == self.own_account_id
 
+    def _getCurrentScreen(self):
+        widget = self.frame.body
+        while isinstance(widget, urwid.Overlay):
+            widget = widget.contents[0][0]
+        return widget
+
+    def runCustomCommand(self, cmd_config):
+        widget = self._getCurrentScreen()
+        # Check context
+        context_name = None
+        for cls, name in SCREEN_CONTEXT_NAMES.items():
+            if isinstance(widget, cls):
+                context_name = name
+                break
+        allowed = cmd_config.get('context')
+        if allowed is not None and context_name not in allowed:
+            return
+        # Get context variables
+        context_vars = {}
+        if hasattr(widget, 'getCustomCommandContext'):
+            context_vars = widget.getCustomCommandContext()
+            if context_vars is None:
+                return
+        # Interpolate (shell-quote values to prevent injection)
+        safe_vars = {k: shlex.quote(v) for k, v in context_vars.items()}
+        try:
+            command = cmd_config['command'].format_map(safe_vars)
+        except KeyError as e:
+            self.error('Variable %s not available on this screen' % e)
+            return
+        # Run
+        self.log.debug("Running custom command: %s", command)
+        inout = open(os.devnull, "r+")
+        try:
+            setsid = getattr(os, 'setsid', None)
+            if not setsid:
+                setsid = getattr(os, 'setpgrp', None)
+            subprocess.Popen(command, shell=True, close_fds=True,
+                             stdin=inout, stdout=inout, stderr=inout,
+                             preexec_fn=setsid)
+            self.loop.screen.clear()
+        except OSError as e:
+            self.error('Failed to run command: %s' % str(e))
+
     def run(self):
         try:
             self.loop.run()
@@ -574,6 +629,9 @@ class App:
         keys =  [(k, self.config.keymap.formatKeys(k), t) for (k, t) in self.getGlobalCommands()]
         for d in self.config.dashboards.values():
             keys.append(('', d['key'], d['name']))
+        for c in self.config.custom_commands.values():
+            desc = c.get('description', c['command'])
+            keys.append(('', c['key'], desc))
         return keys
 
     def help(self):
@@ -762,6 +820,8 @@ class App:
                 self.changeScreen(view)
             except hubtty.search.SearchSyntaxError as e:
                 self.error(e.message)
+        elif key in self.config.custom_commands:
+            self.runCustomCommand(self.config.custom_commands[key])
         elif keymap.FURTHER_INPUT in commands:
             self.input_buffer.append(key)
             msg = ''.join(self.input_buffer)

--- a/hubtty/config.py
+++ b/hubtty/config.py
@@ -90,6 +90,15 @@ class ConfigSchema:
 
     reviewkeys = [reviewkey]
 
+    custom_command = {v.Required('key'): str,
+                      v.Required('command'): str,
+                      v.Optional('description'): str,
+                      v.Optional('context'): [v.Any(
+                          'repository-list', 'pull-request-list',
+                          'pull-request', 'diff')]}
+
+    custom_commands = [custom_command]
+
     hide_comment = {v.Required('author'): str}
 
     hide_comments = [hide_comment]
@@ -116,6 +125,7 @@ class ConfigSchema:
                            'commentlinks': self.commentlinks,
                            'dashboards': self.dashboards,
                            'reviewkeys': self.reviewkeys,
+                           'custom-commands': self.custom_commands,
                            'pr-list-query': str,
                            'diff-view': str,
                            'hide-comments': self.hide_comments,
@@ -213,6 +223,10 @@ class Config:
         self.reviewkeys = collections.OrderedDict()
         for k in self.config.get('reviewkeys', []):
             self.reviewkeys[k['key']] = k
+
+        self.custom_commands = collections.OrderedDict()
+        for c in self.config.get('custom-commands', []):
+            self.custom_commands[c['key']] = c
 
         self.hide_comments = []
         for h in self.config.get('hide-comments', []):

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -125,6 +125,12 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             ret.append(('', keymap.formatKey(k['key']), action))
         return ret
 
+    def getCustomCommandContext(self):
+        return {
+            'repository': self.repository_name,
+            'sha': self.sha,
+        }
+
     def __init__(self, app, new_commit_key):
         super().__init__(urwid.Pile([]))
         self.log = logging.getLogger('hubtty.view.diff')

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -583,6 +583,17 @@ class PullRequestView(urwid.WidgetWrap):
             ret.append(('', keymap.formatKey(k['key']), action))
         return ret
 
+    def getCustomCommandContext(self):
+        return {
+            'repository': self.repository_name,
+            'number': str(self.pr_number),
+            'branch': self.pr_branch or '',
+            'author': self.pr_author or '',
+            'sha': self.pr_sha or '',
+            'title': self.pr_title or '',
+            'url': self.pr_url or '',
+        }
+
     def __init__(self, app, pr_key):
         super().__init__(urwid.Pile([]))
         self.log = logging.getLogger('hubtty.view.pull_request')
@@ -711,6 +722,12 @@ class PullRequestView(urwid.WidgetWrap):
             self.repository_key = pr.repository.key
             self.repository_name = pr.repository.name
             self.pr_rest_id = pr.pr_id
+            self.pr_number = pr.number
+            self.pr_branch = pr.branch
+            self.pr_author = pr.author_name
+            self.pr_title = pr.title
+            self.pr_url = str(pr.html_url)
+            self.pr_sha = pr.commits[-1].sha
             if pr.author:
                 self.author_login = pr.author.username
             else:

--- a/hubtty/view/pull_request_list.py
+++ b/hubtty/view/pull_request_list.py
@@ -341,6 +341,23 @@ class PullRequestListView(urwid.WidgetWrap, mywid.Searchable):
         commands = self.getCommands()
         return [(c[0], key(c[0]), c[1]) for c in commands]
 
+    def getCustomCommandContext(self):
+        if not self.listbox.body:
+            return None
+        pos = self.listbox.focus_position
+        row = self.listbox.body[pos]
+        if not isinstance(row, PullRequestRow):
+            return None
+        with self.app.db.getSession() as session:
+            pr = session.getPullRequest(row.pr_key)
+            return {
+                'repository': pr.repository.name,
+                'number': str(pr.number),
+                'branch': pr.branch or '',
+                'author': pr.author_name or '',
+                'sha': row.commit_sha,
+            }
+
     def __init__(self, app, query, query_desc=None, repository_key=None,
                  unreviewed=False, sort_by=None, reverse=None):
         super().__init__(urwid.Pile([]))

--- a/hubtty/view/repository_list.py
+++ b/hubtty/view/repository_list.py
@@ -236,6 +236,15 @@ class RepositoryListView(urwid.WidgetWrap, mywid.Searchable):
         commands = self.getCommands()
         return [(c[0], key(c[0]), c[1]) for c in commands]
 
+    def getCustomCommandContext(self):
+        if not self.listbox.body:
+            return None
+        pos = self.listbox.focus_position
+        row = self.listbox.body[pos]
+        if not isinstance(row, RepositoryRow):
+            return None
+        return {'repository': row.repository_name}
+
     def __init__(self, app):
         super().__init__(urwid.Pile([]))
         self.log = logging.getLogger('hubtty.view.repository_list')

--- a/tests/test_custom_commands.py
+++ b/tests/test_custom_commands.py
@@ -1,0 +1,165 @@
+# Copyright The Hubtty Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the custom-commands feature."""
+
+import shlex
+
+import pytest
+import voluptuous as v
+
+from hubtty.config import ConfigSchema
+
+
+class TestCustomCommandSchema:
+    """Voluptuous schema validation for custom-commands config entries."""
+
+    def _validate(self, data):
+        schema = v.Schema(ConfigSchema.custom_commands)
+        return schema(data)
+
+    def test_valid_full(self):
+        """Accept a fully-specified custom command."""
+        data = [{'key': 'meta 1',
+                 'command': 'echo {repository}',
+                 'description': 'Say hello',
+                 'context': ['pull-request', 'diff']}]
+        result = self._validate(data)
+        assert result[0]['key'] == 'meta 1'
+        assert result[0]['context'] == ['pull-request', 'diff']
+
+    def test_valid_minimal(self):
+        """Accept a command with only required fields."""
+        data = [{'key': 'meta 2', 'command': 'true'}]
+        result = self._validate(data)
+        assert result[0]['key'] == 'meta 2'
+        assert 'description' not in result[0]
+        assert 'context' not in result[0]
+
+    def test_all_context_values(self):
+        """Accept every valid context name."""
+        data = [{'key': 'meta 3', 'command': 'true',
+                 'context': ['repository-list', 'pull-request-list',
+                             'pull-request', 'diff']}]
+        result = self._validate(data)
+        assert len(result[0]['context']) == 4
+
+    def test_invalid_context(self):
+        """Reject an unknown context name."""
+        data = [{'key': 'meta 1', 'command': 'true',
+                 'context': ['invalid-screen']}]
+        with pytest.raises(v.MultipleInvalid):
+            self._validate(data)
+
+    def test_missing_key(self):
+        """Reject a command missing the required 'key' field."""
+        data = [{'command': 'true'}]
+        with pytest.raises(v.MultipleInvalid):
+            self._validate(data)
+
+    def test_missing_command(self):
+        """Reject a command missing the required 'command' field."""
+        data = [{'key': 'meta 1'}]
+        with pytest.raises(v.MultipleInvalid):
+            self._validate(data)
+
+
+class TestInterpolation:
+    """Variable interpolation and shell-quoting logic."""
+
+    @staticmethod
+    def _interpolate(template, context_vars):
+        """Reproduce the interpolation logic from App.runCustomCommand."""
+        safe_vars = {k: shlex.quote(v) for k, v in context_vars.items()}
+        return template.format_map(safe_vars)
+
+    def test_basic(self):
+        result = self._interpolate(
+            'echo {repository}',
+            {'repository': 'owner/repo'})
+        assert result == 'echo owner/repo'
+
+    def test_multiple_variables(self):
+        result = self._interpolate(
+            'gh pr checkout {number} --repo {repository}',
+            {'number': '42', 'repository': 'owner/repo'})
+        assert result == 'gh pr checkout 42 --repo owner/repo'
+
+    def test_shell_injection_is_quoted(self):
+        """Malicious values must be neutralised by shlex.quote."""
+        malicious = '"; rm -rf / #'
+        result = self._interpolate('echo {title}', {'title': malicious})
+        # shlex.quote wraps the value in single quotes
+        assert result == "echo '\"; rm -rf / #'"
+        # The quoted result must not equal a naive (unquoted) interpolation
+        naive = 'echo {title}'.format_map({'title': malicious})
+        assert result != naive
+
+    def test_single_quote_in_value(self):
+        """Values containing single quotes are still safely quoted."""
+        result = self._interpolate(
+            'echo {title}',
+            {'title': "it's a test"})
+        # shlex.quote handles embedded single quotes
+        assert 'echo ' in result
+        # The value must round-trip safely through a shell
+        assert "it's a test" not in result  # raw form must not appear
+
+    def test_missing_variable_raises(self):
+        with pytest.raises(KeyError):
+            self._interpolate('echo {missing}', {'repository': 'r'})
+
+    def test_empty_value(self):
+        result = self._interpolate('echo {branch}', {'branch': ''})
+        assert result == "echo ''"
+
+
+class TestContextRestriction:
+    """Context-checking logic from App.runCustomCommand."""
+
+    @staticmethod
+    def _is_allowed(cmd_config, context_name):
+        """Reproduce the context-restriction check from runCustomCommand."""
+        allowed = cmd_config.get('context')
+        if allowed is not None and context_name not in allowed:
+            return False
+        return True
+
+    def test_allowed(self):
+        cfg = {'key': 'meta 1', 'command': 'true',
+               'context': ['pull-request', 'diff']}
+        assert self._is_allowed(cfg, 'pull-request') is True
+
+    def test_blocked(self):
+        cfg = {'key': 'meta 1', 'command': 'true',
+               'context': ['pull-request']}
+        assert self._is_allowed(cfg, 'repository-list') is False
+
+    def test_no_context_means_all_screens(self):
+        cfg = {'key': 'meta 1', 'command': 'true'}
+        assert self._is_allowed(cfg, 'repository-list') is True
+        assert self._is_allowed(cfg, 'pull-request') is True
+        assert self._is_allowed(cfg, 'diff') is True
+
+    def test_unknown_screen_blocked_when_restricted(self):
+        cfg = {'key': 'meta 1', 'command': 'true',
+               'context': ['pull-request']}
+        # None represents an unrecognised screen type
+        assert self._is_allowed(cfg, None) is False
+
+    def test_empty_context_blocks_all(self):
+        cfg = {'key': 'meta 1', 'command': 'true',
+               'context': []}
+        assert self._is_allowed(cfg, 'pull-request') is False
+        assert self._is_allowed(cfg, 'repository-list') is False


### PR DESCRIPTION
Add a new 'custom-commands' config section that lets users bind keys to arbitrary shell commands with context variable interpolation.

Each command specifies a key, a shell command string, an optional description, and an optional list of screen contexts where it is available (repository-list, pull-request-list, pull-request, diff).

Context variables are interpolated via {variable} syntax. Available variables depend on the current screen:
```
  - repository-list:   {repository}
  - pull-request-list: {repository}, {number}, {branch}, {author}, {sha}
  - pull-request:      {repository}, {number}, {branch}, {author},
                        {sha}, {title}, {url}
  - diff:              {repository}, {sha}
```

Commands appear in the global help screen and are executed in the background with stdin/stdout/stderr redirected to /dev/null.