### PR TITLE
Fix duplicate checks caused by overlapping GitHub APIs

### DIFF
--- a/hubtty/alembic/versions/f3a1b2c4d5e6_deduplicate_checks_add_unique.py
+++ b/hubtty/alembic/versions/f3a1b2c4d5e6_deduplicate_checks_add_unique.py
@@ -1,0 +1,38 @@
+"""Deduplicate checks and add unique constraint on (commit_key, name)
+
+Revision ID: f3a1b2c4d5e6
+Revises: 1e41885ea284
+Create Date: 2026-06-04 00:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f3a1b2c4d5e6'
+down_revision = '1e41885ea284'
+
+from alembic import op
+
+
+def upgrade():
+    # Step 1: Delete duplicate check rows, keeping the one with the
+    # highest key (most recently inserted) for each (commit_key, name)
+    # pair.
+    op.execute("""
+        DELETE FROM "check"
+        WHERE key NOT IN (
+            SELECT MAX(key)
+            FROM "check"
+            GROUP BY commit_key, name
+        )
+    """)
+
+    # Step 2: Add unique constraint to prevent future duplicates
+    with op.batch_alter_table('check') as batch_op:
+        batch_op.create_unique_constraint(
+            'uq_check_commit_key_name', ['commit_key', 'name']
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('check') as batch_op:
+        batch_op.drop_constraint('uq_check_commit_key_name', type_='unique')

--- a/hubtty/sync/tasks/check_helpers.py
+++ b/hubtty/sync/tasks/check_helpers.py
@@ -118,6 +118,7 @@ def update_checks(session, commit, remote_checks_data: List[Dict[str, Any]]) -> 
                 check_data['name'],
                 check_data['state'], created, created
             )
+            local_checks[check_data['name']] = check
         check.updated = dateutil.parser.parse(check_data['updated'])
         check.state = check_data['state']
         check.url = check_data['url']
@@ -149,14 +150,21 @@ def fetch_checks(sync: 'Sync', repository_name: str,
     Returns:
         List of normalized check data dictionaries.
     """
-    checks = []
+    # Collect from both APIs into a dict keyed by name so that
+    # duplicates (same CI job reported via both APIs) are merged.
+    # Check-runs are processed second so they overwrite statuses
+    # when both exist, since check-runs carry richer data
+    # (started/finished timestamps, etc.).
+    checks_by_name: Dict[str, Dict[str, Any]] = {}
+
     remote_commit_status = sync.get(
         f'repos/{repository_name}/commits/{commit_sha}/status',
         use_etag=use_etag,
     )
     if remote_commit_status is not None:
         for check in remote_commit_status['statuses']:
-            checks.append(check_result_from_status(check))
+            result = check_result_from_status(check)
+            checks_by_name[result['name']] = result
 
     remote_commit_check_runs = sync.get(
         f'repos/{repository_name}/commits/{commit_sha}/check-runs?per_page=100',
@@ -164,9 +172,10 @@ def fetch_checks(sync: 'Sync', repository_name: str,
     )
     if remote_commit_check_runs is not None:
         for check in remote_commit_check_runs:
-            checks.append(check_result_from_check_run(check))
+            result = check_result_from_check_run(check)
+            checks_by_name[result['name']] = result
 
-    return checks
+    return list(checks_by_name.values())
 
 
 def has_pending_checks(checks_data: List[Dict[str, Any]],

--- a/tests/sync/test_check_helpers.py
+++ b/tests/sync/test_check_helpers.py
@@ -369,6 +369,70 @@ class TestFetchChecks:
         assert len(result) == 1
         assert result[0]['name'] == 'ci/only'
 
+    def test_duplicate_name_check_run_wins(self):
+        """When both APIs report the same name, check-run overwrites status."""
+        sync = Mock()
+        sync.get.side_effect = [
+            {'statuses': [
+                {'context': 'ci/build', 'target_url': 'http://old',
+                 'state': 'pending', 'description': 'Waiting for status',
+                 'created_at': '2024-01-01T10:00:00Z',
+                 'updated_at': '2024-01-01T10:00:00Z'},
+            ]},
+            [
+                {'name': 'ci/build', 'html_url': 'http://new',
+                 'status': 'completed', 'conclusion': 'success',
+                 'started_at': '2024-01-01T10:00:00Z',
+                 'completed_at': '2024-01-01T10:05:00Z'},
+            ],
+        ]
+        result = fetch_checks(sync, 'owner/repo', 'abc123')
+        assert len(result) == 1
+        assert result[0]['name'] == 'ci/build'
+        assert result[0]['state'] == 'success'
+        assert result[0]['url'] == 'http://new'
+
+    def test_multiple_duplicates_deduplicated(self):
+        """Several overlapping names are all deduplicated."""
+        sync = Mock()
+        sync.get.side_effect = [
+            {'statuses': [
+                {'context': 'ci/a', 'state': 'success', 'description': 'ok',
+                 'created_at': '2024-01-01T10:00:00Z',
+                 'updated_at': '2024-01-01T10:05:00Z'},
+                {'context': 'ci/b', 'state': 'pending', 'description': 'wait',
+                 'created_at': '2024-01-01T10:00:00Z',
+                 'updated_at': '2024-01-01T10:00:00Z'},
+                {'context': 'ci/only-status', 'state': 'success',
+                 'description': 'ok',
+                 'created_at': '2024-01-01T10:00:00Z',
+                 'updated_at': '2024-01-01T10:05:00Z'},
+            ]},
+            [
+                {'name': 'ci/a', 'html_url': 'http://a',
+                 'status': 'completed', 'conclusion': 'failure',
+                 'started_at': '2024-01-01T10:00:00Z',
+                 'completed_at': '2024-01-01T10:03:00Z'},
+                {'name': 'ci/b', 'html_url': 'http://b',
+                 'status': 'completed', 'conclusion': 'success',
+                 'started_at': '2024-01-01T10:00:00Z',
+                 'completed_at': '2024-01-01T10:04:00Z'},
+                {'name': 'ci/only-check', 'html_url': 'http://c',
+                 'status': 'completed', 'conclusion': 'success',
+                 'started_at': '2024-01-01T10:00:00Z',
+                 'completed_at': '2024-01-01T10:02:00Z'},
+            ],
+        ]
+        result = fetch_checks(sync, 'owner/repo', 'abc123')
+        names = [c['name'] for c in result]
+        assert sorted(names) == ['ci/a', 'ci/b', 'ci/only-check',
+                                  'ci/only-status']
+        # check-run values should win for the overlapping names
+        by_name = {c['name']: c for c in result}
+        assert by_name['ci/a']['state'] == 'failure'
+        assert by_name['ci/b']['state'] == 'success'
+        assert by_name['ci/b']['url'] == 'http://b'
+
 
 class TestUpdateChecks:
     """Tests for update_checks."""
@@ -521,3 +585,28 @@ class TestUpdateChecks:
         assert existing.state == 'success'
         # ci/brand-new should be created
         commit.createCheck.assert_called_once()
+
+    def test_duplicate_names_in_input_creates_only_one(self):
+        """Duplicate names in remote data must not create duplicate DB rows."""
+        session = Mock()
+        commit = self._make_commit([])
+        created_check = Mock()
+        commit.createCheck.return_value = created_check
+
+        # Two entries with the same name (simulates pre-dedup data)
+        checks_data = [
+            {'name': 'ci/dup', 'state': 'pending', 'url': 'http://old',
+             'message': 'Job triggered',
+             'created': '2024-01-01T10:00:00Z',
+             'updated': '2024-01-01T10:00:00Z'},
+            {'name': 'ci/dup', 'state': 'success', 'url': 'http://new',
+             'message': 'Job succeeded',
+             'created': '2024-01-01T10:00:00Z',
+             'updated': '2024-01-01T10:05:00Z'},
+        ]
+        update_checks(session, commit, checks_data)
+
+        # Only one check should be created; second entry updates it
+        commit.createCheck.assert_called_once()
+        assert created_check.state == 'success'
+        assert created_check.url == 'http://new'


### PR DESCRIPTION
fetch_checks() queries both the commit statuses API and the check runs API, but many CI systems (including GitHub Actions) report through both.  The results were blindly concatenated, producing entries with the same name.  update_checks() then created duplicate DB rows because its local_checks lookup dict was built once before the loop and never updated after inserting new checks.

Fix by:
- Deduplicating in fetch_checks() using a dict keyed by name; check runs (richer data) overwrite statuses when both exist.
- Updating local_checks after createCheck() so a second entry with the same name updates the existing row.
- Adding an Alembic migration that deletes existing duplicate rows and adds a UNIQUE(commit_key, name) constraint on the check table.