### PR TITLE
Fix NOT NULL crash for parentless commits during PR sync

### DIFF
--- a/hubtty/gitrepo.py
+++ b/hubtty/gitrepo.py
@@ -22,6 +22,11 @@ import re
 import git
 import gitdb
 
+# The well-known SHA of git's empty tree object.  Used as the synthetic
+# parent for root commits that have no real parent so that ``git diff
+# <empty-tree> <sha>`` shows the full content as additions.
+EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf899d15006bc06b3'
+
 OLD = 0
 NEW = 1
 START = 0

--- a/hubtty/sync/tasks/pull_request.py
+++ b/hubtty/sync/tasks/pull_request.py
@@ -241,7 +241,7 @@ class SyncPullRequestTask(Task):
                     if remote_commit['parents']:
                         parent_sha = remote_commit['parents'][0]['sha']
                     else:
-                        parent_sha = None
+                        parent_sha = gitrepo.EMPTY_TREE_SHA
 
                     commit = pr.createCommit(
                         (remote_commit['commit']['message'] or '').replace('\r', ''),

--- a/hubtty/sync/tasks/repository_check.py
+++ b/hubtty/sync/tasks/repository_check.py
@@ -91,7 +91,9 @@ class CheckCommitsTask(Task):
             for pr in repository.open_prs:
                 if repo:
                     for commit in pr.commits:
-                        if repo.checkCommits([commit.parent, commit.sha]):
+                        shas_to_check = [s for s in (commit.parent, commit.sha)
+                                         if s != gitrepo.EMPTY_TREE_SHA]
+                        if shas_to_check and repo.checkCommits(shas_to_check):
                             to_sync.add(pr.pr_id)
                 else:
                     to_sync.add(pr.pr_id)

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -677,6 +677,7 @@ class PullRequestView(urwid.WidgetWrap):
             for commit in pr.commits:
                 shas.add(commit.parent)
                 shas.add(commit.sha)
+        shas.discard(gitrepo.EMPTY_TREE_SHA)
         repo = gitrepo.get_repo(pr_repository_name, self.app.config)
         missing_commits = repo.checkCommits(shas)
         if missing_commits:

--- a/tests/sync/test_pull_request.py
+++ b/tests/sync/test_pull_request.py
@@ -18,6 +18,7 @@
 from unittest.mock import Mock, MagicMock, patch
 
 from hubtty.sync.tasks.pull_request import SyncPullRequestTask
+from hubtty.gitrepo import EMPTY_TREE_SHA
 
 
 # ---------------------------------------------------------------------------
@@ -289,3 +290,50 @@ class TestSyncPullRequestCommitDetailSkip:
             "Known commit SHA_A should not be fetched"
         assert f'repos/{REPO}/commits/{SHA_B}' in detail_urls, \
             "New commit SHA_B should be fetched"
+
+
+class TestSyncPullRequestParentlessCommit:
+    """Verify that commits with no parents use the empty-tree SHA."""
+
+    @patch('hubtty.sync.tasks.pull_request.gitrepo')
+    def test_parentless_commit_uses_empty_tree_sha(
+            self, mock_gitrepo, mock_sync):
+        """A root commit (no parents) stores EMPTY_TREE_SHA as parent."""
+        remote_pr = _make_remote_pr()
+        # Build a single commit with an empty parents list.
+        remote_commits = [{
+            'sha': SHA_A,
+            'commit': {'message': 'initial squashed import'},
+            'parents': [],
+        }]
+        commit_details = {
+            SHA_A: _make_commit_detail(SHA_A),
+        }
+
+        # Supply a local_pr mock so we can inspect createCommit calls
+        # directly on it (no commits yet → getCommitBySha returns None).
+        local_pr = MagicMock()
+        local_pr.pr_id = PR_ID
+        local_pr.number = 1
+        local_pr.state = 'open'
+        local_pr.labels = []
+        local_pr.commits = []
+        local_pr.repository = MagicMock(name=REPO)
+        local_pr.repository.name = REPO
+        local_pr.getCommitBySha = Mock(return_value=None)
+
+        _setup_sync(
+            mock_sync, remote_pr, remote_commits, commit_details,
+            local_pr=local_pr,
+        )
+
+        mock_gitrepo.EMPTY_TREE_SHA = EMPTY_TREE_SHA
+        task = SyncPullRequestTask(PR_ID)
+        task.run(mock_sync)
+
+        # createCommit must have been called with EMPTY_TREE_SHA as parent.
+        local_pr.createCommit.assert_called_once_with(
+            'initial squashed import',
+            SHA_A,
+            EMPTY_TREE_SHA,
+        )


### PR DESCRIPTION
Commits with no parents (e.g. from git subtree add --squash) caused an IntegrityError because parent_sha was set to None, violating the NOT NULL constraint on commit.parent.

Use git's well-known empty tree SHA (4b825dc6...) as the parent for root commits. This satisfies the constraint and works correctly with all downstream consumers: diff views show all files as additions, commit lookups return None (no match), and git operations resolve the universal empty tree object.