### PR TITLE
Add ability to run async commands

### DIFF
--- a/examples/reference-hubtty.yaml
+++ b/examples/reference-hubtty.yaml
@@ -333,9 +333,12 @@ dashboards:
 #     timeout: 60
 #     context:
 #       - pull-request
-#   - key: 'meta 3'
-#     command: 'notify-send Hubtty {repository}'
-#     description: 'Desktop notification for repository'
+#   - key: 'meta r'
+#     command: 'tmux split-window -v "cd {repo_path} && git checkout origin/HEAD && claude \"/review https://github.com/{repository}/pull/{number}\""'
+#     description: 'Review PR with coding agent'
+#     context:
+#       - pull-request
+#       - pull-request-list
 
 # 'size-column' is a set of customize parameters for the 'Size' column
 # on your dashboard.

--- a/examples/reference-hubtty.yaml
+++ b/examples/reference-hubtty.yaml
@@ -292,17 +292,33 @@ dashboards:
 # variable interpolation from the current screen.
 #
 # Available contexts and their variables:
-#   repository-list:   {repository}
-#   pull-request-list: {repository}, {number}, {branch}, {author}, {sha}
-#   pull-request:      {repository}, {number}, {branch}, {author}, {sha},
-#                      {title}, {url}
-#   diff:              {repository}, {sha}
+#   repository-list:   {repository}, {repo_path}
+#   pull-request-list: {repository}, {repo_path}, {number}, {branch},
+#                      {author}, {sha}
+#   pull-request:      {repository}, {repo_path}, {number}, {branch},
+#                      {author}, {sha}, {title}, {url}
+#   diff:              {repository}, {repo_path}, {sha}
+#
+# {repo_path} is constructed as <git-root>/<repository> (see the
+# 'git-root' config option).  It is the local clone path, not the
+# GitHub URL.
 #
 # If 'context' is omitted, the command is available on all screens
 # (but interpolation will fail if a variable is not available).
 #
 # Variable values are automatically shell-quoted for safety.
 # To pass unquoted values, use command wrappers or scripts.
+#
+# Commands run in the directory from which hubtty was launched.
+# Use 'cd {repo_path} &&' or 'git -C {repo_path}' to operate
+# inside a repository checkout.
+#
+# By default commands run in the background (fire-and-forget).
+# Set 'show-output: true' to run synchronously and display the
+# command's stdout/stderr in a dialog when it finishes.
+#
+# The default timeout is 30 seconds; override with 'timeout: <seconds>'.
+#
 # custom-commands:
 #   - key: 'meta 1'
 #     command: 'xdg-open https://github.com/{repository}/pull/{number}'
@@ -313,6 +329,8 @@ dashboards:
 #   - key: 'meta 2'
 #     command: 'gh pr checkout {number} --repo {repository}'
 #     description: 'Checkout PR with gh CLI'
+#     show-output: true
+#     timeout: 60
 #     context:
 #       - pull-request
 #   - key: 'meta 3'

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -40,7 +40,6 @@ import urwid
 
 from hubtty import db
 from hubtty import config
-from hubtty import gitrepo
 from hubtty import keymap
 from hubtty import mywid
 from hubtty import palette
@@ -1035,31 +1034,6 @@ class App:
         self.updateStatusQueries()
         return ret
 
-    def localCheckoutCommit(self, repository_name, commit_sha):
-        repo = gitrepo.get_repo(repository_name, self.config)
-        try:
-            repo.checkout(commit_sha)
-            dialog = mywid.MessageDialog('Checkout', 'Pull request checked out in %s' % repo.path)
-            min_height=8
-        except gitrepo.GitCheckoutError as e:
-            dialog = mywid.MessageDialog('Error', e.msg)
-            min_height=12
-        urwid.connect_signal(dialog, 'close',
-            lambda button: self.backScreen())
-        self.popup(dialog, min_height=min_height)
-
-    def localCherryPickCommit(self, repository_name, commit_sha):
-        repo = gitrepo.get_repo(repository_name, self.config)
-        try:
-            repo.cherryPick(commit_sha)
-            dialog = mywid.MessageDialog('Cherry-Pick', 'Pull request cherry-picked in %s' % repo.path)
-            min_height=8
-        except gitrepo.GitCheckoutError as e:
-            dialog = mywid.MessageDialog('Error', e.msg)
-            min_height=12
-        urwid.connect_signal(dialog, 'close',
-            lambda button: self.backScreen())
-        self.popup(dialog, min_height=min_height)
 
     def saveReviews(self, commit_keys, approval, message, upload, merge):
         message_keys = []

--- a/hubtty/app.py
+++ b/hubtty/app.py
@@ -15,6 +15,7 @@
 
 import argparse
 import colorsys
+import dataclasses
 import datetime
 import dateutil
 import fcntl
@@ -22,6 +23,7 @@ import functools
 import logging
 import os
 import re
+import signal
 import shlex
 import socket
 import subprocess
@@ -60,6 +62,14 @@ SCREEN_CONTEXT_NAMES = {
     view_side_diff.SideDiffView: 'diff',
     view_unified_diff.UnifiedDiffView: 'diff',
 }
+
+
+@dataclasses.dataclass
+class _ForegroundCmdState:
+    """State for a running foreground custom command."""
+    overlay: object
+    description: str
+
 
 WELCOME_TEXT = """\
 Welcome to Hubtty!
@@ -389,6 +399,9 @@ class App:
         self.logged_warnings = set()
         self.command_pipe = self.loop.watch_pipe(self._commandPipeInput)
         self.command_queue = queue.Queue()
+        self.custom_cmd_pipe = self.loop.watch_pipe(self._customCmdPipeInput)
+        self.custom_cmd_queue = queue.Queue()
+        self._fg_cmd = None  # _ForegroundCmdState while a command is in flight
 
         warnings.showwarning = self._showWarning
 
@@ -475,17 +488,117 @@ class App:
             return
         # Run
         self.log.debug("Running custom command: %s", command)
-        inout = open(os.devnull, "r+")
+        if cmd_config.get('show-output'):
+            if self._fg_cmd is not None:
+                self.error('A command has not yet finished: %s'
+                           % self._fg_cmd.description)
+                return
+            description = cmd_config.get('description', command)
+            timeout = cmd_config.get('timeout', 30)
+            self._runCustomCommandForeground(command, description, timeout)
+        else:
+            self._runCustomCommandBackground(command)
+
+    def _runCustomCommandBackground(self, command):
+        # Popen duplicates these fds internally before returning, so
+        # closing them when the with-block exits is safe.
+        with open(os.devnull, "r+") as inout:
+            try:
+                subprocess.Popen(command, shell=True, close_fds=True,
+                                 stdin=inout, stdout=inout, stderr=inout,
+                                 start_new_session=True)
+                self.loop.screen.clear()
+            except OSError as e:
+                self.error('Failed to run command: %s' % str(e))
+
+    def _runCustomCommandForeground(self, command, description, timeout=30):
+        # Show a "Running..." popup immediately.  This gives the user
+        # visual feedback and captures focus so the key cannot be
+        # pressed again while the command is in flight.
+        dialog = mywid.MessageDialog('Running', description)
+        urwid.connect_signal(dialog, 'close',
+            lambda button: self.backScreen())
+        self.popup(dialog, min_height=6)
+        # Remember the overlay so the pipe callback can tell whether
+        # the user already dismissed it (via OK or Esc).
+        self._fg_cmd = _ForegroundCmdState(
+            overlay=self.frame.body, description=description)
+        t = threading.Thread(
+            target=self._runCustomCommandWorker,
+            args=(command, description, timeout), daemon=True)
+        t.start()
+
+    def _runCustomCommandWorker(self, command, description, timeout=30):
+        """Run *command* in a thread; deliver the result via pipe."""
         try:
-            setsid = getattr(os, 'setsid', None)
-            if not setsid:
-                setsid = getattr(os, 'setpgrp', None)
-            subprocess.Popen(command, shell=True, close_fds=True,
-                             stdin=inout, stdout=inout, stderr=inout,
-                             preexec_fn=setsid)
-            self.loop.screen.clear()
+            # start_new_session puts the shell and all its children
+            # into a new process group so we can kill the whole tree
+            # on timeout (not just the shell).
+            process = subprocess.Popen(
+                command, shell=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                start_new_session=True)
+            try:
+                stdout, _ = process.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                # Kill the entire process group (shell + children).
+                try:
+                    os.killpg(process.pid, signal.SIGTERM)
+                except OSError:
+                    pass
+                # Collect any partial output and reap the process.
+                # Use a second timeout + SIGKILL so we never block
+                # indefinitely if the process ignores SIGTERM.
+                try:
+                    stdout, _ = process.communicate(timeout=5)
+                except subprocess.TimeoutExpired:
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except OSError:
+                        pass
+                    stdout, _ = process.communicate()
+                if len(stdout) > 65536:
+                    stdout = b'[...truncated...]\n' + stdout[-65536:]
+                partial = stdout.decode('utf-8', errors='replace').strip()
+                title = '%s (timed out)' % description
+                message = ('Command did not complete within %d'
+                           ' seconds.' % timeout)
+                if partial:
+                    message += '\n\n' + partial
+                self.custom_cmd_queue.put((title, message))
+                os.write(self.custom_cmd_pipe, b'result\n')
+                return
+            if len(stdout) > 65536:
+                stdout = b'[...truncated...]\n' + stdout[-65536:]
+            output = stdout.decode('utf-8', errors='replace').strip()
+            if process.returncode == 0:
+                title = description
+                message = output or 'Command completed successfully.'
+            else:
+                title = '%s (exit %d)' % (description, process.returncode)
+                message = output or 'Command failed with no output.'
         except OSError as e:
-            self.error('Failed to run command: %s' % str(e))
+            title = '%s (error)' % description
+            message = 'Failed to run command: %s' % str(e)
+        self.custom_cmd_queue.put((title, message))
+        os.write(self.custom_cmd_pipe, b'result\n')
+
+    def _customCmdPipeInput(self, data=None):
+        """Called on the main thread when a foreground command finishes."""
+        try:
+            (title, message) = self.custom_cmd_queue.get_nowait()
+        except queue.Empty:
+            return
+        # Pop the "Running..." popup only if it is still on screen.
+        # The user may have already dismissed it with OK or Esc.
+        if self._fg_cmd and self.frame.body is self._fg_cmd.overlay:
+            self.backScreen()
+        self._fg_cmd = None
+        dialog = mywid.MessageDialog(title, message)
+        urwid.connect_signal(dialog, 'close',
+            lambda button: self.backScreen())
+        self.popup(dialog, min_height=max(8, min(20, message.count('\n') + 6)))
 
     def run(self):
         try:

--- a/hubtty/config.py
+++ b/hubtty/config.py
@@ -93,6 +93,8 @@ class ConfigSchema:
     custom_command = {v.Required('key'): str,
                       v.Required('command'): str,
                       v.Optional('description'): str,
+                      v.Optional('show-output'): bool,
+                      v.Optional('timeout'): v.All(int, v.Range(min=1)),
                       v.Optional('context'): [v.Any(
                           'repository-list', 'pull-request-list',
                           'pull-request', 'diff')]}

--- a/hubtty/gitrepo.py
+++ b/hubtty/gitrepo.py
@@ -289,11 +289,6 @@ class DiffFile:
         self.old_lineno += 1
         self.new_lineno += 1
 
-class GitCheckoutError(Exception):
-    def __init__(self, msg):
-        super().__init__(msg)
-        self.msg = msg
-
 class GitCloneError(Exception):
     def __init__(self, msg):
         super().__init__(msg)
@@ -355,28 +350,6 @@ class Repo:
         except git.exc.GitCommandError as e:
             self.log.error("Failed to delete ref: %s", e.stderr)
 
-    def checkout(self, ref):
-        repo = git.Repo(self.path)
-        try:
-            repo.git.checkout(ref)
-        except git.exc.GitCommandError as e:
-            raise GitCheckoutError(e.stderr.replace('\t', '    '))
-
-    def cherryPick(self, ref):
-        repo = git.Repo(self.path)
-        try:
-            repo.git.cherry_pick(ref)
-        except git.exc.GitCommandError as e:
-            raise GitCheckoutError(e.stderr.replace('\t', '    '))
-
-    def diffstat(self, old, new):
-        repo = git.Repo(self.path)
-        diff = repo.git.diff('-M', '--color=never', '--numstat', old, new)
-        ret = []
-        for x in diff.split('\n'):
-            # Added, removed, filename
-            ret.append(x.split('\t'))
-        return ret
 
     trailing_ws_re = re.compile(r'\s+$')
     def _emph_trail_ws(self, style, line):

--- a/hubtty/keymap.py
+++ b/hubtty/keymap.py
@@ -48,8 +48,6 @@ TOGGLE_HELD = 'toggle held'
 TOGGLE_MARK = 'toggle process mark'
 REVIEW = 'review'
 DIFF = 'diff'
-LOCAL_CHECKOUT = 'local checkout'
-LOCAL_CHERRY_PICK = 'local cherry pick'
 SEARCH_RESULTS = 'search results'
 NEXT_PR = 'next pull request'
 PREV_PR = 'previous pull request'
@@ -117,8 +115,6 @@ DEFAULT_KEYMAP = {
     TOGGLE_MARK: '%',
     REVIEW: 'r',
     DIFF: 'd',
-    LOCAL_CHECKOUT: 'c',
-    LOCAL_CHERRY_PICK: 'x',
     SEARCH_RESULTS: 'u',
     NEXT_PR: 'n',
     PREV_PR: 'p',

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -14,6 +14,7 @@
 
 import datetime
 import logging
+import os
 
 import urwid
 
@@ -129,6 +130,8 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
         return {
             'repository': self.repository_name,
             'sha': self.sha,
+            'repo_path': os.path.join(self.app.config.git_root,
+                                      self.repository_name),
         }
 
     def __init__(self, app, new_commit_key):

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -320,11 +320,7 @@ class CommitRow(urwid.WidgetWrap):
         focus_map={'commit-button': 'focused-commit-button'}
         self.review_button = ReviewButton(self)
         buttons = [mywid.FixedButton(('commit-button', "Diff"),
-                                     on_press=self.diff),
-                   mywid.FixedButton(('commit-button', "Local Checkout"),
-                                     on_press=self.checkout),
-                   mywid.FixedButton(('commit-button', "Local Cherry-Pick"),
-                                     on_press=self.cherryPick)]
+                                     on_press=self.diff)]
 
         buttons = [('pack', urwid.AttrMap(b, None, focus_map=focus_map)) for b in buttons]
         buttons = urwid.Columns(buttons + [urwid.Text('')], dividechars=2)
@@ -363,11 +359,6 @@ class CommitRow(urwid.WidgetWrap):
     def diff(self, button):
         self.pr_view.diff(self.commit_key)
 
-    def checkout(self, button):
-        self.app.localCheckoutCommit(self.repository_name, self.commit_sha)
-
-    def cherryPick(self, button):
-        self.app.localCherryPickCommit(self.repository_name, self.commit_sha)
 
 class PullRequestButton(urwid.Button):
     button_left = urwid.Text(' ')
@@ -532,8 +523,6 @@ class PrDescriptionBox(mywid.HyperText):
 class PullRequestView(urwid.WidgetWrap):
     def getCommands(self):
         return [
-            (keymap.LOCAL_CHECKOUT,
-             "Checkout the pull request into the local repo"),
             (keymap.DIFF,
              "Show the diff of the first commit"),
             (keymap.TOGGLE_HIDDEN,
@@ -554,8 +543,6 @@ class PullRequestView(urwid.WidgetWrap):
              "Toggle the reviewed flag for the current pull request"),
             (keymap.TOGGLE_STARRED,
              "Toggle the starred flag for the current pull request"),
-            (keymap.LOCAL_CHERRY_PICK,
-             "Cherry-pick the most recent commit onto the local repo"),
             (keymap.CLOSE_PR,
              "Close this pull request"),
             (keymap.EDIT_PULL_REQUEST,
@@ -1025,14 +1012,6 @@ class PullRequestView(urwid.WidgetWrap):
         if keymap.DIFF in commands:
             row = self.commit_rows[self.first_commit_key]
             row.diff(None)
-            return None
-        if keymap.LOCAL_CHECKOUT in commands:
-            row = self.commit_rows[self.last_commit_key]
-            row.checkout(None)
-            return None
-        if keymap.LOCAL_CHERRY_PICK in commands:
-            row = self.commit_rows[self.last_commit_key]
-            row.cherryPick(None)
             return None
         if keymap.SEARCH_RESULTS in commands:
             widget = self.app.findPullRequestList()

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -595,6 +595,8 @@ class PullRequestView(urwid.WidgetWrap):
             'sha': self.pr_sha or '',
             'title': self.pr_title or '',
             'url': self.pr_url or '',
+            'repo_path': os.path.join(self.app.config.git_root,
+                                      self.repository_name),
         }
 
     def __init__(self, app, pr_key):

--- a/hubtty/view/pull_request_list.py
+++ b/hubtty/view/pull_request_list.py
@@ -305,8 +305,6 @@ class PullRequestListView(urwid.WidgetWrap, mywid.Searchable):
         return [
             (keymap.TOGGLE_HELD,
              "Toggle the held flag for the currently selected pull request"),
-            (keymap.LOCAL_CHECKOUT,
-             "Checkout the selected pull request into the local repo"),
             (keymap.TOGGLE_HIDDEN,
              "Toggle the hidden flag for the currently selected PR"),
             (keymap.TOGGLE_LIST_REVIEWED,
@@ -702,13 +700,6 @@ class PullRequestListView(urwid.WidgetWrap, mywid.Searchable):
                 self.reverse = True
             self.clearPullRequestList()
             self.refresh()
-            return True
-        if keymap.LOCAL_CHECKOUT in commands:
-            if not len(self.listbox.body):
-                return True
-            pos = self.listbox.focus_position
-            row = self.listbox.body[pos]
-            self.app.localCheckoutCommit(row.repository_name, row.commit_sha)
             return True
         if keymap.REFINE_PR_SEARCH in commands:
             default = self.getQueryString()

--- a/hubtty/view/pull_request_list.py
+++ b/hubtty/view/pull_request_list.py
@@ -15,6 +15,7 @@
 
 import datetime
 import logging
+import os
 
 import urwid
 
@@ -350,12 +351,15 @@ class PullRequestListView(urwid.WidgetWrap, mywid.Searchable):
             return None
         with self.app.db.getSession() as session:
             pr = session.getPullRequest(row.pr_key)
+            repo_path = os.path.join(self.app.config.git_root,
+                                     pr.repository.name)
             return {
                 'repository': pr.repository.name,
                 'number': str(pr.number),
                 'branch': pr.branch or '',
                 'author': pr.author_name or '',
                 'sha': row.commit_sha,
+                'repo_path': repo_path,
             }
 
     def __init__(self, app, query, query_desc=None, repository_key=None,

--- a/hubtty/view/repository_list.py
+++ b/hubtty/view/repository_list.py
@@ -14,6 +14,7 @@
 # under the License.
 
 import logging
+import os
 import urwid
 
 import hubtty.search
@@ -243,7 +244,10 @@ class RepositoryListView(urwid.WidgetWrap, mywid.Searchable):
         row = self.listbox.body[pos]
         if not isinstance(row, RepositoryRow):
             return None
-        return {'repository': row.repository_name}
+        repo_path = os.path.join(self.app.config.git_root,
+                                 row.repository_name)
+        return {'repository': row.repository_name,
+                'repo_path': repo_path}
 
     def __init__(self, app):
         super().__init__(urwid.Pile([]))

--- a/tests/test_custom_commands.py
+++ b/tests/test_custom_commands.py
@@ -14,11 +14,17 @@
 
 """Tests for the custom-commands feature."""
 
+import queue
 import shlex
+import signal
+import subprocess
+import types
+from unittest import mock
 
 import pytest
 import voluptuous as v
 
+from hubtty.app import App
 from hubtty.config import ConfigSchema
 
 
@@ -38,6 +44,36 @@ class TestCustomCommandSchema:
         result = self._validate(data)
         assert result[0]['key'] == 'meta 1'
         assert result[0]['context'] == ['pull-request', 'diff']
+
+    def test_valid_show_output(self):
+        """Accept a command with show-output enabled."""
+        data = [{'key': 'meta 1',
+                 'command': 'git -C {repo_path} checkout {sha}',
+                 'show-output': True}]
+        result = self._validate(data)
+        assert result[0]['show-output'] is True
+
+    def test_show_output_false(self):
+        """Accept show-output set to False."""
+        data = [{'key': 'meta 1',
+                 'command': 'true',
+                 'show-output': False}]
+        result = self._validate(data)
+        assert result[0]['show-output'] is False
+
+    def test_show_output_rejects_non_bool(self):
+        """Reject a non-boolean show-output value."""
+        data = [{'key': 'meta 1',
+                 'command': 'true',
+                 'show-output': 'yes'}]
+        with pytest.raises(v.MultipleInvalid):
+            self._validate(data)
+
+    def test_show_output_optional(self):
+        """show-output is optional and absent by default."""
+        data = [{'key': 'meta 1', 'command': 'true'}]
+        result = self._validate(data)
+        assert 'show-output' not in result[0]
 
     def test_valid_minimal(self):
         """Accept a command with only required fields."""
@@ -89,6 +125,21 @@ class TestInterpolation:
             'echo {repository}',
             {'repository': 'owner/repo'})
         assert result == 'echo owner/repo'
+
+    def test_repo_path_variable(self):
+        """The repo_path variable is usable in command templates."""
+        result = self._interpolate(
+            'git -C {repo_path} checkout {sha}',
+            {'repo_path': '/home/user/git/owner/repo',
+             'sha': 'abc1234'})
+        assert result == 'git -C /home/user/git/owner/repo checkout abc1234'
+
+    def test_repo_path_with_spaces(self):
+        """repo_path with spaces is safely quoted."""
+        result = self._interpolate(
+            'git -C {repo_path} status',
+            {'repo_path': '/home/user/my repos/owner/repo'})
+        assert "'" in result  # shlex.quote wraps in single quotes
 
     def test_multiple_variables(self):
         result = self._interpolate(
@@ -163,3 +214,180 @@ class TestContextRestriction:
                'context': []}
         assert self._is_allowed(cfg, 'pull-request') is False
         assert self._is_allowed(cfg, 'repository-list') is False
+
+
+class TestShowOutputRouting:
+    """Verify show-output flag routes to foreground vs background."""
+
+    @staticmethod
+    def _should_run_foreground(cmd_config):
+        """Reproduce the routing logic from App.runCustomCommand."""
+        return bool(cmd_config.get('show-output'))
+
+    def test_show_output_true_is_foreground(self):
+        cfg = {'key': 'c', 'command': 'git checkout {sha}',
+               'show-output': True}
+        assert self._should_run_foreground(cfg) is True
+
+    def test_show_output_false_is_background(self):
+        cfg = {'key': 'c', 'command': 'notify-send hi',
+               'show-output': False}
+        assert self._should_run_foreground(cfg) is False
+
+    def test_show_output_absent_is_background(self):
+        cfg = {'key': 'c', 'command': 'notify-send hi'}
+        assert self._should_run_foreground(cfg) is False
+
+
+class TestTimeoutSchema:
+    """Schema validation for the timeout field."""
+
+    def _validate(self, data):
+        schema = v.Schema(ConfigSchema.custom_commands)
+        return schema(data)
+
+    def test_timeout_accepts_positive_int(self):
+        data = [{'key': 'meta 1', 'command': 'true', 'timeout': 60}]
+        result = self._validate(data)
+        assert result[0]['timeout'] == 60
+
+    def test_timeout_rejects_string(self):
+        data = [{'key': 'meta 1', 'command': 'true', 'timeout': 'abc'}]
+        with pytest.raises(v.MultipleInvalid):
+            self._validate(data)
+
+    def test_timeout_rejects_zero(self):
+        data = [{'key': 'meta 1', 'command': 'true', 'timeout': 0}]
+        with pytest.raises(v.MultipleInvalid):
+            self._validate(data)
+
+    def test_timeout_rejects_negative(self):
+        data = [{'key': 'meta 1', 'command': 'true', 'timeout': -5}]
+        with pytest.raises(v.MultipleInvalid):
+            self._validate(data)
+
+
+class TestForegroundCommandWorker:
+    """Integration tests for App._runCustomCommandWorker."""
+
+    @staticmethod
+    def _make_harness():
+        """Create a minimal stand-in with the attributes the worker needs."""
+        obj = types.SimpleNamespace()
+        obj.custom_cmd_queue = queue.Queue()
+        obj.custom_cmd_pipe = 99  # dummy fd
+        return obj
+
+    @mock.patch('hubtty.app.os.write')
+    @mock.patch('hubtty.app.subprocess.Popen')
+    def test_success(self, mock_popen, mock_write):
+        proc = mock_popen.return_value
+        proc.communicate.return_value = (b'hello world\n', None)
+        proc.returncode = 0
+
+        harness = self._make_harness()
+        App._runCustomCommandWorker(harness, 'echo hi', 'Test cmd', timeout=30)
+
+        title, message = harness.custom_cmd_queue.get_nowait()
+        assert title == 'Test cmd'
+        assert 'hello world' in message
+        mock_write.assert_called_once_with(99, b'result\n')
+
+    @mock.patch('hubtty.app.os.write')
+    @mock.patch('hubtty.app.subprocess.Popen')
+    def test_failure_exit_code(self, mock_popen, mock_write):
+        proc = mock_popen.return_value
+        proc.communicate.return_value = (b'error occurred\n', None)
+        proc.returncode = 1
+
+        harness = self._make_harness()
+        App._runCustomCommandWorker(harness, 'false', 'Failing cmd', timeout=30)
+
+        title, message = harness.custom_cmd_queue.get_nowait()
+        assert '(exit 1)' in title
+        assert 'error occurred' in message
+
+    @mock.patch('hubtty.app.os.write')
+    @mock.patch('hubtty.app.os.killpg')
+    @mock.patch('hubtty.app.subprocess.Popen')
+    def test_timeout_sends_sigterm(self, mock_popen, mock_killpg, mock_write):
+        proc = mock_popen.return_value
+        proc.pid = 12345
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired('cmd', 5),
+            (b'partial output', None),
+        ]
+
+        harness = self._make_harness()
+        App._runCustomCommandWorker(harness, 'sleep 100', 'Slow cmd', timeout=5)
+
+        mock_killpg.assert_called_with(12345, signal.SIGTERM)
+        title, message = harness.custom_cmd_queue.get_nowait()
+        assert '(timed out)' in title
+        assert 'did not complete within 5' in message
+        assert 'partial output' in message
+
+    @mock.patch('hubtty.app.os.write')
+    @mock.patch('hubtty.app.os.killpg')
+    @mock.patch('hubtty.app.subprocess.Popen')
+    def test_timeout_escalates_to_sigkill(self, mock_popen, mock_killpg,
+                                          mock_write):
+        proc = mock_popen.return_value
+        proc.pid = 12345
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired('cmd', 5),
+            subprocess.TimeoutExpired('cmd', 5),
+            (b'', None),
+        ]
+
+        harness = self._make_harness()
+        App._runCustomCommandWorker(harness, 'sleep 100', 'Stubborn cmd',
+                                    timeout=5)
+
+        assert mock_killpg.call_count == 2
+        mock_killpg.assert_any_call(12345, signal.SIGTERM)
+        mock_killpg.assert_any_call(12345, signal.SIGKILL)
+        title, message = harness.custom_cmd_queue.get_nowait()
+        assert '(timed out)' in title
+
+    @mock.patch('hubtty.app.os.write')
+    @mock.patch('hubtty.app.subprocess.Popen')
+    def test_oserror(self, mock_popen, mock_write):
+        mock_popen.side_effect = OSError('No such file')
+
+        harness = self._make_harness()
+        App._runCustomCommandWorker(harness, '/no/such/cmd', 'Bad cmd',
+                                    timeout=30)
+
+        title, message = harness.custom_cmd_queue.get_nowait()
+        assert '(error)' in title
+        assert 'No such file' in message
+
+    @mock.patch('hubtty.app.os.write')
+    @mock.patch('hubtty.app.subprocess.Popen')
+    def test_large_output_truncated(self, mock_popen, mock_write):
+        proc = mock_popen.return_value
+        proc.communicate.return_value = (b'x' * 200000, None)
+        proc.returncode = 0
+
+        harness = self._make_harness()
+        App._runCustomCommandWorker(harness, 'cat big', 'Big output',
+                                    timeout=30)
+
+        title, message = harness.custom_cmd_queue.get_nowait()
+        assert '[...truncated...]' in message
+        assert len(message) < 70000
+
+    @mock.patch('hubtty.app.os.write')
+    @mock.patch('hubtty.app.subprocess.Popen')
+    def test_empty_output_success(self, mock_popen, mock_write):
+        proc = mock_popen.return_value
+        proc.communicate.return_value = (b'', None)
+        proc.returncode = 0
+
+        harness = self._make_harness()
+        App._runCustomCommandWorker(harness, 'true', 'Silent cmd', timeout=30)
+
+        title, message = harness.custom_cmd_queue.get_nowait()
+        assert title == 'Silent cmd'
+        assert message == 'Command completed successfully.'


### PR DESCRIPTION
Add show-output option for custom commands: when set, the command runs in a background thread with stdout/stderr captured, showing a 'Running...' dialog while in flight and a result dialog on completion. A guard flag prevents duplicate execution while a command is already
running.

Add timeout option (default 30s) with process-group cleanup on expiry.

Remove built-in local checkout and local cherry-pick commands that can be replaced by configuration using this new mechanism.