### PR TITLE
Treat all 5xx errors as transient (offline) instead of failing the task

### DIFF
--- a/hubtty/sync/http.py
+++ b/hubtty/sync/http.py
@@ -79,10 +79,10 @@ class HTTPClient:
             response: The HTTP response to check.
 
         Raises:
-            OfflineError: If the server returned 503.
+            OfflineError: If the server returned a 5xx error.
             RestrictedError: If OAuth app restrictions block access.
             RateLimitError: If rate limit is exceeded.
-            Exception: For other 4xx/5xx status codes.
+            Exception: For other 4xx status codes.
         """
         self.log.debug('HTTP status code: %d', response.status_code)
 
@@ -90,9 +90,11 @@ class HTTPClient:
         if response.status_code == 429:
             self._handle_rate_limit_response(response)
 
-        # Handle 503 (service unavailable)
-        if response.status_code == 503:
-            raise OfflineError("Received 503 status code")
+        # Handle 5xx (server errors) -- transient; treat as offline to retry
+        if response.status_code >= 500:
+            raise OfflineError(
+                f"Received {response.status_code} status code"
+            )
 
         # Handle 403 (forbidden)
         elif response.status_code == 403:

--- a/tests/sync/test_http.py
+++ b/tests/sync/test_http.py
@@ -76,12 +76,13 @@ class TestHTTPHeaders:
 class TestCheckResponse:
     """Tests for response validation."""
 
-    def test_503_raises_offline(self, http_client):
-        """503 response raises OfflineError."""
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 504])
+    def test_5xx_raises_offline(self, http_client, status_code):
+        """5xx responses raise OfflineError."""
         response = Mock()
-        response.status_code = 503
+        response.status_code = status_code
 
-        with pytest.raises(OfflineError):
+        with pytest.raises(OfflineError, match=str(status_code)):
             http_client.checkResponse(response)
 
     def test_403_oauth_restriction_raises_restricted(self, http_client):


### PR DESCRIPTION
Previously only 503 raised OfflineError for graceful backoff and retry. Other 5xx codes (500, 502, 504) fell through to the generic Exception handler, which logged a full traceback and permanently failed the task.

Broaden the check from == 503 to >= 500 so all server errors get the same offline/backoff/retry treatment.