### PR TITLE
Detect search API truncation and fall back to per-repo queries

### DIFF
--- a/hubtty/sync/http.py
+++ b/hubtty/sync/http.py
@@ -19,6 +19,7 @@ import json
 import logging
 import re
 import time
+from collections import namedtuple
 from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
 
 import requests
@@ -28,6 +29,8 @@ from .exceptions import OfflineError, RestrictedError, RateLimitError
 
 if TYPE_CHECKING:
     from hubtty.app import App
+
+SearchResult = namedtuple('SearchResult', ['items', 'total_count'])
 
 
 class HTTPClient:
@@ -336,6 +339,9 @@ class HTTPClient:
                 # results from multiple pages are correctly merged
                 # into a single flat list.
                 if isinstance(result, dict) and 'items' in result:
+                    if is_first_page:
+                        self._last_search_total_count = result.get(
+                            'total_count')
                     result = result.get('items', [])
                 elif isinstance(result, dict) and 'check_runs' in result:
                     result = result.get('check_runs', [])
@@ -517,15 +523,19 @@ class HTTPClient:
         """
         self._mutating_request('delete', path, data, headers, response_callback)
 
-    def query(self, query: str) -> Any:
+    def query(self, query: str) -> SearchResult:
         """Execute a GitHub search query.
 
         Args:
             query: Search query string.
 
         Returns:
-            List of search results.
+            SearchResult with *items* (list) and *total_count* (int or None).
+            When *total_count* exceeds ``len(items)``, the GitHub Search API
+            silently truncated the results (hard cap of 1 000 per query).
         """
+        self._last_search_total_count = None
         q = f'search/issues?per_page=100&q={query}'
         self.log.debug('Query: %s', q)
-        return self.get(q)
+        items = self.get(q)
+        return SearchResult(items, self._last_search_total_count)

--- a/hubtty/sync/tasks/repository.py
+++ b/hubtty/sync/tasks/repository.py
@@ -261,9 +261,34 @@ class SyncRepositoryTask(Task):
                     full_sync.append(repository.name)
 
         def sync_repositories(repositories, query):
+            base_query = query
             for repository_name in repositories:
                 query += f' repo:{repository_name}'
-            pull_requests = sync.query(query)
+            result = sync.query(query)
+            pull_requests = result.items
+
+            if (result.total_count is not None
+                    and result.total_count > len(pull_requests)):
+                # The batched query exceeded the GitHub Search API's
+                # 1 000-result cap.  Fall back to per-repo queries so
+                # every repository gets complete results.
+                self.log.warning(
+                    "Search results truncated (%d/%d). "
+                    "Re-querying repositories individually.",
+                    len(pull_requests), result.total_count)
+                pull_requests = []
+                for repository_name in repositories:
+                    r = sync.query(
+                        f'{base_query} repo:{repository_name}')
+                    if (r.total_count is not None
+                            and r.total_count > len(r.items)):
+                        self.log.warning(
+                            "Search results for %s still truncated "
+                            "(%d/%d)",
+                            repository_name, len(r.items),
+                            r.total_count)
+                    pull_requests.extend(r.items)
+
             pr_ids = [pr['pull_request']['url'].split('repos/')[1] for pr in pull_requests]
             with app.db.getSession() as session:
                 # Winnow the list of IDs to only the ones in the local DB.

--- a/tests/sync/conftest.py
+++ b/tests/sync/conftest.py
@@ -17,6 +17,8 @@
 import pytest
 from unittest.mock import Mock, MagicMock
 
+from hubtty.sync.http import SearchResult
+
 
 @pytest.fixture
 def mock_app():
@@ -45,6 +47,6 @@ def mock_sync(mock_app):
     sync.put = Mock()
     sync.patch = Mock()
     sync.delete = Mock()
-    sync.query = Mock(return_value=[])
+    sync.query = Mock(return_value=SearchResult([], None))
     sync.submitTask = Mock()
     return sync

--- a/tests/sync/test_http.py
+++ b/tests/sync/test_http.py
@@ -18,7 +18,7 @@ import pytest
 from unittest.mock import Mock, patch
 import json
 
-from hubtty.sync.http import HTTPClient
+from hubtty.sync.http import HTTPClient, SearchResult
 from hubtty.sync.exceptions import OfflineError, RateLimitError, RestrictedError
 
 
@@ -616,6 +616,51 @@ class TestQuery:
         call_arg = mock_get.call_args[0][0]
         assert 'search/issues' in call_arg
         assert 'type:pr' in call_arg
+
+    def test_query_returns_search_result(self, http_client):
+        """query() returns a SearchResult namedtuple."""
+        with patch.object(http_client, 'get', return_value=[]):
+            result = http_client.query('type:pr state:open')
+
+        assert isinstance(result, SearchResult)
+        assert result.items == []
+        assert result.total_count is None
+
+    def test_query_returns_total_count(self, http_client):
+        """query() captures total_count from the search response."""
+        response = Mock()
+        response.status_code = 200
+        response.text = json.dumps({
+            'total_count': 1523,
+            'incomplete_results': False,
+            'items': [{'id': 1}, {'id': 2}],
+        })
+        response.headers = {'X-RateLimit-Remaining': '100'}
+        response.links = {}
+
+        with patch.object(http_client.session, 'get', return_value=response):
+            result = http_client.query('type:pr state:open')
+
+        assert isinstance(result, SearchResult)
+        assert len(result.items) == 2
+        assert result.total_count == 1523
+
+    def test_query_total_count_matches_when_not_truncated(self, http_client):
+        """total_count equals len(items) when results are not truncated."""
+        response = Mock()
+        response.status_code = 200
+        response.text = json.dumps({
+            'total_count': 2,
+            'incomplete_results': False,
+            'items': [{'id': 1}, {'id': 2}],
+        })
+        response.headers = {'X-RateLimit-Remaining': '100'}
+        response.links = {}
+
+        with patch.object(http_client.session, 'get', return_value=response):
+            result = http_client.query('type:pr state:open')
+
+        assert result.total_count == len(result.items)
 
 
 class TestETagSupport:

--- a/tests/sync/test_repository.py
+++ b/tests/sync/test_repository.py
@@ -1,0 +1,159 @@
+# Copyright The Hubtty Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Tests for repository synchronization tasks."""
+
+from unittest.mock import Mock, MagicMock
+
+from hubtty.sync.http import SearchResult
+from hubtty.sync.tasks.repository import SyncRepositoryTask
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_pr(repo_name, number, state='open'):
+    """Build a minimal search-result PR dict."""
+    return {
+        'pull_request': {
+            'url': f'https://api.github.com/repos/{repo_name}/pulls/{number}',
+        },
+        'state': state,
+    }
+
+
+def _setup_sync(mock_sync, repositories):
+    """Configure mock_sync and app with the given repositories.
+
+    *repositories* is a list of (key, name, updated) tuples.
+    Returns the list of repository keys.
+    """
+    repo_mocks = {}
+    for key, name, updated in repositories:
+        repo = Mock()
+        repo.key = key
+        repo.name = name
+        repo.updated = updated
+        repo_mocks[key] = repo
+
+    session = MagicMock()
+    session.getRepository = Mock(side_effect=lambda k: repo_mocks[k])
+    session.getPullRequestIDs = Mock(return_value=set())
+
+    mock_sync.app.db.getSession.return_value.__enter__ = Mock(
+        return_value=session)
+    mock_sync.app.db.getSession.return_value.__exit__ = Mock(
+        return_value=False)
+
+    return [key for key, _, _ in repositories]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSyncRepositoryTaskTruncation:
+    """Tests for search-result truncation handling."""
+
+    def test_no_truncation_uses_batch_results(self, mock_sync):
+        """When total_count == len(items), no per-repo fallback occurs."""
+        keys = _setup_sync(mock_sync, [
+            (1, 'org/repo-a', None),
+            (2, 'org/repo-b', None),
+        ])
+
+        prs = [_make_pr('org/repo-a', 1), _make_pr('org/repo-b', 2)]
+        mock_sync.query = Mock(
+            return_value=SearchResult(prs, len(prs)))
+
+        task = SyncRepositoryTask(keys)
+        task.run(mock_sync)
+
+        # query() should have been called exactly once (the batch query).
+        mock_sync.query.assert_called_once()
+        q = mock_sync.query.call_args[0][0]
+        assert 'repo:org/repo-a' in q
+        assert 'repo:org/repo-b' in q
+
+    def test_truncation_falls_back_to_per_repo(self, mock_sync):
+        """When total_count > len(items), per-repo queries are issued."""
+        keys = _setup_sync(mock_sync, [
+            (1, 'org/repo-a', None),
+            (2, 'org/repo-b', None),
+        ])
+
+        batch_prs = [_make_pr('org/repo-a', i) for i in range(5)]
+        repo_a_prs = [_make_pr('org/repo-a', i) for i in range(3)]
+        repo_b_prs = [_make_pr('org/repo-b', i) for i in range(4)]
+
+        mock_sync.query = Mock(side_effect=[
+            # First call: truncated batch result
+            SearchResult(batch_prs, 1500),
+            # Per-repo fallback calls
+            SearchResult(repo_a_prs, len(repo_a_prs)),
+            SearchResult(repo_b_prs, len(repo_b_prs)),
+        ])
+
+        task = SyncRepositoryTask(keys)
+        task.run(mock_sync)
+
+        assert mock_sync.query.call_count == 3
+        # First call is the batch
+        batch_q = mock_sync.query.call_args_list[0][0][0]
+        assert 'repo:org/repo-a' in batch_q
+        assert 'repo:org/repo-b' in batch_q
+        # Second and third are per-repo
+        repo_a_q = mock_sync.query.call_args_list[1][0][0]
+        assert 'repo:org/repo-a' in repo_a_q
+        assert 'repo:org/repo-b' not in repo_a_q
+        repo_b_q = mock_sync.query.call_args_list[2][0][0]
+        assert 'repo:org/repo-b' in repo_b_q
+        assert 'repo:org/repo-a' not in repo_b_q
+
+    def test_truncation_submits_tasks_from_fallback(self, mock_sync):
+        """Per-repo fallback results are used to submit SyncPullRequestTasks."""
+        keys = _setup_sync(mock_sync, [
+            (1, 'org/repo-a', None),
+        ])
+
+        mock_sync.query = Mock(side_effect=[
+            SearchResult([], 500),  # truncated batch
+            SearchResult([_make_pr('org/repo-a', 1),
+                          _make_pr('org/repo-a', 2)], 2),
+        ])
+
+        task = SyncRepositoryTask(keys)
+        task.run(mock_sync)
+
+        # Two open PRs -> two SyncPullRequestTask + one SetRepositoryUpdatedTask
+        pr_task_calls = [
+            c for c in mock_sync.submitTask.call_args_list
+            if 'SyncPullRequestTask' in type(c[0][0]).__name__
+        ]
+        assert len(pr_task_calls) == 2
+
+    def test_no_truncation_when_total_count_is_none(self, mock_sync):
+        """When total_count is None, treat as not truncated."""
+        keys = _setup_sync(mock_sync, [
+            (1, 'org/repo-a', None),
+        ])
+
+        prs = [_make_pr('org/repo-a', 1)]
+        mock_sync.query = Mock(return_value=SearchResult(prs, None))
+
+        task = SyncRepositoryTask(keys)
+        task.run(mock_sync)
+
+        mock_sync.query.assert_called_once()


### PR DESCRIPTION
The GitHub Search API silently caps results at 1,000 per query. When SyncRepositoryTask batches up to 10 repositories into a single search query, the combined results can exceed this limit, causing PRs to be missed and repository PR counts to be wrong.

Capture total_count from the search response (previously discarded) and return it via a new SearchResult namedtuple from query().  When total_count > len(items), fall back to querying each repository individually so every repo gets complete results.