### PR TITLE
Fix publish workflow: fetch full history for setuptools-scm

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Install Python 3.13


### PR DESCRIPTION
The checkout step defaults to fetch-depth=1 (shallow clone), which does not include git tags. This causes setuptools-scm to produce a fallback version like 0.1.dev1+gb4ebee854 instead of the tagged version, which PyPI rejects due to local version identifiers.

Setting fetch-depth=0 ensures all tags are available so setuptools-scm resolves the correct version from the release tag.