### PR TITLE
Detect generated files dynamically instead of caching in DB

### DIFF
--- a/hubtty/alembic/versions/b4c7d8e9f0a1_add_generated_to_file.py
+++ b/hubtty/alembic/versions/b4c7d8e9f0a1_add_generated_to_file.py
@@ -1,4 +1,7 @@
-"""Add generated column to file table
+"""Drop generated column from file table (if present)
+
+The generated-file status is now computed dynamically at view time
+using ``GeneratedFileFilter`` instead of being cached in the DB.
 
 Revision ID: b4c7d8e9f0a1
 Revises: f3a1b2c4d5e6
@@ -15,42 +18,16 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    with op.batch_alter_table('file') as batch_op:
-        batch_op.add_column(
-            sa.Column('generated', sa.Boolean(), nullable=False,
-                      server_default=sa.text('0')))
-
-    # Backfill existing rows: mark files whose path matches a built-in
-    # generated-file pattern.  Only built-in heuristics are applied
-    # here (no .gitattributes or user config available at migration
-    # time); newly synced files will pick up all sources at sync time.
-    from hubtty.generated import BUILTIN_GENERATED_PATTERNS, _match_pattern
-
     conn = op.get_bind()
-    result = conn.execute(sa.text('SELECT key, path FROM file'))
-
-    keys_to_update = []
-    while True:
-        rows = result.fetchmany(1000)
-        if not rows:
-            break
-        for key, path in rows:
-            for pattern in BUILTIN_GENERATED_PATTERNS:
-                if _match_pattern(pattern, path):
-                    keys_to_update.append(int(key))
-                    break
-
-    # Batch UPDATE to avoid overly large statements.
-    batch_size = 500
-    for i in range(0, len(keys_to_update), batch_size):
-        chunk = keys_to_update[i:i + batch_size]
-        conn.execute(
-            sa.text('UPDATE file SET generated = 1 WHERE key IN :keys').bindparams(
-                sa.bindparam('keys', value=chunk, expanding=True)
-            )
-        )
+    inspector = sa.inspect(conn)
+    columns = [c['name'] for c in inspector.get_columns('file')]
+    if 'generated' in columns:
+        with op.batch_alter_table('file') as batch_op:
+            batch_op.drop_column('generated')
 
 
 def downgrade():
     with op.batch_alter_table('file') as batch_op:
-        batch_op.drop_column('generated')
+        batch_op.add_column(
+            sa.Column('generated', sa.Boolean(), nullable=False,
+                      server_default=sa.text('0')))

--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -168,7 +168,6 @@ file_table = Table(
     Column('inserted', Integer),
     Column('deleted', Integer),
     Column('status', String(16), index=True, nullable=False),
-    Column('generated', Boolean, nullable=False, server_default=text('0')),
     )
 server_table = Table(
     'server', metadata,
@@ -553,14 +552,13 @@ class PendingMerge:
 
 class File:
     def __init__(self, commit, path, status, old_path=None,
-                 inserted=None, deleted=None, generated=False):
+                 inserted=None, deleted=None):
         self.commit_key = commit.key
         self.path = path
         self.status = status
         self.old_path = old_path
         self.inserted = inserted
         self.deleted = deleted
-        self.generated = generated
 
     @property
     def display_path(self):

--- a/hubtty/generated.py
+++ b/hubtty/generated.py
@@ -81,6 +81,10 @@ BUILTIN_GENERATED_PATTERNS = [
     '*.Designer.cs',
     '*.g.cs',
     '*.generated.cs',
+    # Vendored dependencies
+    'vendor/**',
+    'node_modules/**',
+    'third_party/**',
 ]
 
 

--- a/hubtty/sync/tasks/pull_request.py
+++ b/hubtty/sync/tasks/pull_request.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING
 import dateutil.parser
 
 from hubtty import gitrepo
-from hubtty.generated import GeneratedFileFilter
 from ..task import Task
 from ..constants import LOW_PRIORITY
 from ..events import RepositoryAddedEvent, PullRequestAddedEvent, PullRequestUpdatedEvent
@@ -231,16 +230,6 @@ class SyncPullRequestTask(Task):
                     pr.removeLabel(label)
 
             repo = gitrepo.get_repo(pr.repository.name, app.config)
-            # Build the generated-file filter once for the whole PR
-            # using the head commit's .gitattributes.  This avoids
-            # creating a new git.Repo and re-reading the blob for
-            # every commit.
-            if remote_commits:
-                generated_filter = GeneratedFileFilter(
-                    repo_path=repo.path,
-                    commit_sha=remote_commits[-1]['sha'],
-                    user_patterns=app.config.generated_files,
-                )
             for remote_commit in remote_commits:
                 commit = pr.getCommitBySha(remote_commit['sha'])
                 # TODO: handle multiple parents
@@ -279,12 +268,7 @@ class SyncPullRequestTask(Task):
                             file['filename'], file['status'],
                             file.get('previous_filename'),
                             inserted, deleted,
-                            generated=generated_filter.is_generated(
-                                file['filename']),
                         )
-                    else:
-                        f.generated = generated_filter.is_generated(
-                            file['filename'])
 
                 # Commit checks
                 if '_hubtty_checks' in remote_commit:

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -22,6 +22,7 @@ from hubtty import gitrepo
 from hubtty import keymap
 from hubtty import mywid
 from hubtty import sync
+from hubtty.generated import GeneratedFileFilter
 from hubtty.view import mouse_scroll_decorator
 
 
@@ -181,15 +182,17 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             self.pr_key = new_commit.pull_request.key
             self.repository_name = new_commit.pull_request.repository.name
             self.sha = new_commit.sha
-            self._generated_paths = set()
             self._files_with_comments = set()
+            repo_path = os.path.join(self.app.config.git_root,
+                                     self.repository_name)
+            self._generated_filter = GeneratedFileFilter(
+                repo_path=repo_path,
+                commit_sha=self.sha,
+                user_patterns=self.app.config.generated_files,
+            )
             for f in new_commit.files:
                 new_comments += f.current_comments
                 self.new_file_keys[f.path] = f.key
-                if f.generated:
-                    self._generated_paths.add(f.path)
-                    if f.old_path:
-                        self._generated_paths.add(f.old_path)
                 if f.current_comments or f.draft_comments:
                     self._files_with_comments.add(f.path)
                     if f.old_path:
@@ -534,10 +537,15 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             pr_view.reviewKey(reviewkey)
         self.app.backScreen()
 
+    _DIFF_SENTINELS = frozenset({'Empty file', 'Unknown File', '/dev/null'})
+
     def _is_generated_diff(self, diff):
         """Return True if *diff* corresponds to a generated file."""
-        return (diff.newname in self._generated_paths
-                or diff.oldname in self._generated_paths)
+        for name in (diff.newname, diff.oldname):
+            if name and name not in self._DIFF_SENTINELS:
+                if self._generated_filter.is_generated(name):
+                    return True
+        return False
 
     def _has_comments(self, diff):
         """Return True if *diff* has inline comments."""

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -26,6 +26,7 @@ from hubtty import keymap
 from hubtty import mywid
 from hubtty import sync
 from hubtty import markdown
+from hubtty.generated import GeneratedFileFilter
 from hubtty.view import side_diff as view_side_diff
 from hubtty.view import unified_diff as view_unified_diff
 from hubtty.view import mouse_scroll_decorator
@@ -304,6 +305,14 @@ class CommitRow(urwid.WidgetWrap):
         generated_added = 0
         generated_removed = 0
         hide_generated = app.config.hide_generated_files
+        if hide_generated:
+            repo_path = os.path.join(app.config.git_root,
+                                     self.repository_name)
+            generated_filter = GeneratedFileFilter(
+                repo_path=repo_path,
+                commit_sha=commit.sha,
+                user_patterns=app.config.generated_files,
+            )
         for rfile in commit.files:
             if rfile.status is None:
                 continue
@@ -311,7 +320,7 @@ class CommitRow(urwid.WidgetWrap):
             removed = rfile.deleted or 0
             total_added += added
             total_removed += removed
-            if hide_generated and rfile.generated:
+            if hide_generated and generated_filter.is_generated(rfile.path):
                 generated_count += 1
                 generated_added += added
                 generated_removed += removed

--- a/tests/sync/test_pull_request.py
+++ b/tests/sync/test_pull_request.py
@@ -205,7 +205,6 @@ def _setup_sync(mock_sync, remote_pr, remote_commits, commit_details,
 
     # Mock gitrepo.get_repo
     app.config.ignore_pending_checks = []
-    app.config.generated_files = []
     app.repository_cache = MagicMock()
 
     return mock_sync
@@ -493,7 +492,6 @@ def _setup_checks_task_sync(mock_sync, pr_mock):
 
     mock_sync.app.db.getSession = make_session
     mock_sync.app.config.ignore_pending_checks = []
-    mock_sync.app.config.generated_files = []
 
 
 class TestSyncPullRequestChecksTaskRun:

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -239,6 +239,18 @@ class TestGeneratedFileFilter:
         assert filt.is_generated('Model.g.cs')
         assert filt.is_generated('Dto.generated.cs')
 
+    def test_builtin_vendor_directories(self):
+        filt = GeneratedFileFilter()
+        assert filt.is_generated('vendor/lib.go')
+        assert filt.is_generated('vendor/github.com/foo/bar/baz.go')
+        assert filt.is_generated('node_modules/lodash/index.js')
+        assert filt.is_generated('node_modules/@scope/pkg/lib.js')
+        assert filt.is_generated('third_party/protobuf/message.cc')
+        assert filt.is_generated('third_party/deep/nested/file.h')
+        # Files that merely *contain* the word vendor are not matched.
+        assert not filt.is_generated('src/vendor.go')
+        assert not filt.is_generated('my_vendor_lib.py')
+
     def test_normal_files_not_generated(self):
         filt = GeneratedFileFilter()
         assert not filt.is_generated('main.py')


### PR DESCRIPTION
The generated-file status was stored as a column on the file table and computed at sync time.  This had two bugs:

1. The GeneratedFileFilter was constructed before git fetch, so .gitattributes could never be read from the commit (it didn't exist locally yet).  On re-syncs the known-commit optimisation skipped re-evaluating files, so .gitattributes patterns were never effectively applied.

2. vendor/** was not in BUILTIN_GENERATED_PATTERNS, so vendored dependencies were only detectable via .gitattributes (broken by bug 1) or user config.

Rather than fixing the cache invalidation, drop the DB column entirely and compute the status at view time using GeneratedFileFilter.  At ~7 ms for filter construction (including reading .gitattributes from a git blob) and ~40 ms for 1500 is_generated() calls, the cost is negligible compared to the git diff and rendering work already done by the view layer.

This means:
- No migration backfill needed
- No sync-time computation or race conditions
- Config/pattern changes take effect immediately on next view
- Files truncated by the GitHub API (>300 per commit) are still detected via the live filter in the diff view

Changes:
- Add vendor/**, node_modules/**, third_party/** to built-in patterns
- Remove generated column from file table and DB model
- Replace add-column migration with drop-column migration
- Remove all generated-filter logic from the sync task
- Build GeneratedFileFilter at view time in diff and PR detail views
- Add tests for vendor directory detection