### PR TITLE
Add commit range diff support

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -341,6 +341,13 @@ For example, to hide comments from a CI system:
    hide-comments:
      - author: "^(.*CI|Jenkins)$"
 
+**diff-default**
+  Controls which diff is opened when pressing `d` in the pull request
+  view.  The values ``first-commit`` (the default) and ``full`` are
+  supported.  ``first-commit`` opens the diff for the first (or
+  selected) commit.  ``full`` opens a combined diff of all commits in
+  the pull request.
+
 **diff-view**
   Specifies how patch diffs should be displayed.  The values `unified`
   or `side-by-side` (the default) are supported.

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -59,5 +59,25 @@ a diff, press the `toggle diff view` key (`F2` in the default keymap,
 `td` in the vi keymap) to switch between the two layouts at runtime
 without changing the configuration file.
 
+Commit Range Diffs (Interdiff)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Hubtty supports viewing diffs for arbitrary ranges of commits within a
+pull request.  Press `D` in the pull request view or any diff view to
+open the commit range dialog.  Select the starting ("From") and ending
+("To") commits, then press Diff to display the combined diff for that
+range.  Selecting "Base" as the starting point diffs from the PR base
+to the chosen commit.
+
+In the diff view, the "Commit (1/N)" label at the top is clickable and
+also opens the commit range dialog.  Individual commit entries listed
+below it can be clicked (or activated with Enter) to expand and show
+the full commit message, rendered with markdown and commentlinks.
+In single-commit view, the commit message is expanded by default.
+
+The `diff-default` configuration option controls the default behavior
+of the `d` key in the pull request view (see the configuration
+documentation for details).
+
 To select text (e.g., to copy to the clipboard), hold Shift while
 selecting the text.

--- a/examples/reference-hubtty.yaml
+++ b/examples/reference-hubtty.yaml
@@ -191,6 +191,11 @@ commentlinks:
 # a review.
 # close-pr-on-review: true
 
+# Controls which diff is opened when pressing 'd' in the pull request
+# view.  'first-commit' (the default) opens the diff for the first (or
+# selected) commit.  'full' opens a combined diff of all commits.
+# diff-default: first-commit
+
 # Uncomment the following line to use a unified diff view instead
 # of the default side-by-side:
 # diff-view: unified

--- a/hubtty/config.py
+++ b/hubtty/config.py
@@ -129,6 +129,7 @@ class ConfigSchema:
                            'reviewkeys': self.reviewkeys,
                            'custom-commands': self.custom_commands,
                            'pr-list-query': str,
+                           'diff-default': v.Any('first-commit', 'full'),
                            'diff-view': str,
                            'syntax-highlighting': bool,
                            'max-highlight-size': int,
@@ -247,6 +248,7 @@ class Config:
         self.repository_pr_list_query = self.config.get('pr-list-query', 'state:open')
 
         self.diff_view = self.config.get('diff-view', 'side-by-side')
+        self.diff_default = self.config.get('diff-default', 'first-commit')
 
         self.syntax_highlighting = self.config.get('syntax-highlighting', True)
         self.max_highlight_size = self.config.get('max-highlight-size',

--- a/hubtty/keymap.py
+++ b/hubtty/keymap.py
@@ -48,6 +48,7 @@ TOGGLE_HELD = 'toggle held'
 TOGGLE_MARK = 'toggle process mark'
 REVIEW = 'review'
 DIFF = 'diff'
+INTERDIFF = 'interdiff'
 SEARCH_RESULTS = 'search results'
 NEXT_PR = 'next pull request'
 PREV_PR = 'previous pull request'
@@ -116,6 +117,7 @@ DEFAULT_KEYMAP = {
     TOGGLE_MARK: '%',
     REVIEW: 'r',
     DIFF: 'd',
+    INTERDIFF: 'D',
     SEARCH_RESULTS: 'u',
     NEXT_PR: 'n',
     PREV_PR: 'p',
@@ -176,6 +178,7 @@ VI_KEYMAP = {
     TOGGLE_GENERATED_FILES: [['t', 'g']],
 
     EDIT_PULL_REQUEST: 'ctrl e',
+    INTERDIFF: 'D',
 }
 
 URWID_COMMANDS = frozenset((

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -20,6 +20,7 @@ import urwid
 
 from hubtty import gitrepo
 from hubtty import keymap
+from hubtty import markdown
 from hubtty import mywid
 from hubtty import sync
 from hubtty.generated import GeneratedFileFilter
@@ -96,6 +97,46 @@ class DiffContextButton(urwid.WidgetWrap):
 
     def next(self, button):
         self.view.expandChunk(self.diff, self.chunk, from_end=-10)
+
+class DiffCommitEntry(urwid.WidgetWrap):
+    """An expandable commit entry for the diff view's commit summary."""
+    _focus_map = {
+        'commit-name': 'focused-commit-name',
+        'commit-sha': 'focused-commit-sha',
+    }
+
+    def __init__(self, app, sha, message, repository_name=None):
+        subject = message.split('\n')[0]
+        self.title = mywid.TextButton(
+            [('commit-sha', '  ' + sha[0:7]),
+             ('commit-name', ' ' + subject)],
+            on_press=self.expandContract)
+        self.title._w = urwid.AttrMap(
+            self.title.text, None, focus_map=self._focus_map)
+        # Build the detail body: rendered commit message or placeholder.
+        body_text = message.split('\n', 1)[1].rstrip() if '\n' in message else ''
+        if body_text:
+            md = markdown.Renderer(app)
+            rendered = md.render(body_text)
+            context = {'repository': repository_name} if repository_name else None
+            for commentlink in app.config.commentlinks:
+                rendered = commentlink.run(app, rendered, context)
+            body_content = mywid.HyperText(rendered)
+        else:
+            body_content = urwid.Text(('md-emphasis', 'Empty commit message'))
+        self.body = urwid.Padding(body_content, left=10)
+        self.pile = urwid.Pile([self.title])
+        super().__init__(self.pile)
+        self.expanded = False
+
+    def expandContract(self, button):
+        if self.expanded:
+            self.pile.contents.pop()
+            self.expanded = False
+        else:
+            self.pile.contents.append((self.body, ('pack', None)))
+            self.expanded = True
+
 
 @mouse_scroll_decorator.ScrollByWheel
 class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
@@ -205,7 +246,7 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                     if not found_base:
                         continue
                     self._commit_summary.append(
-                        (c.sha, c.message.split('\n')[0]))
+                        (c.key, c.sha, c.message))
                     if c.key == self.new_commit_key:
                         break
                 # If base_sha is the first commit's parent (full PR
@@ -213,7 +254,7 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                 if not self._commit_summary:
                     for c in pr.commits:
                         self._commit_summary.append(
-                            (c.sha, c.message.split('\n')[0]))
+                            (c.key, c.sha, c.message))
                         if c.key == self.new_commit_key:
                             break
                 # If still empty (data inconsistency), include all
@@ -232,7 +273,7 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                 if n == 1:
                     # Single commit in range — use the normal
                     # single-commit title format.
-                    subject = self._commit_summary[0][1]
+                    subject = self._commit_summary[0][2].split('\n')[0]
                     self.title = 'Diff of {} — {} {}'.format(
                         repo_name,
                         new_commit.sha[0:7], subject)
@@ -248,7 +289,7 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             else:
                 subject = new_commit.message.split('\n')[0]
                 self._commit_summary = [
-                    (new_commit.sha, subject)]
+                    (new_commit.key, new_commit.sha, new_commit.message)]
                 self.title = 'Diff of {} — {} {}'.format(
                     repo_name,
                     new_commit.sha[0:7], subject)
@@ -256,8 +297,8 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             # Compute 1-based positions within the full PR commit list.
             all_shas = [c.sha for c in pr.commits]
             self._total_commits = len(all_shas)
-            first_sha = self._commit_summary[0][0]
-            last_sha = self._commit_summary[-1][0]
+            first_sha = self._commit_summary[0][1]
+            last_sha = self._commit_summary[-1][1]
             try:
                 self._range_start = all_shas.index(first_sha) + 1
             except ValueError:
@@ -348,10 +389,14 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                 focus_map={None: 'focused-filename',
                            'filename': 'focused-filename'})
             lines.append(commit_label)
-            for sha, subject in self._commit_summary:
-                lines.append(urwid.Text(
-                    [('commit-sha', '  ' + sha[0:7]),
-                     ('commit-name', ' ' + subject)]))
+            single_commit = (len(self._commit_summary) == 1)
+            for commit_key, sha, message in self._commit_summary:
+                entry = DiffCommitEntry(
+                    self.app, sha, message,
+                    repository_name=self.repository_name)
+                if single_commit:
+                    entry.expandContract(None)
+                lines.append(entry)
             lines.append(urwid.Text(''))
         self.file_diffs = [{}, {}]  # Mapping of fn -> DiffFile object (old, new)
         # this is a list of files:

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -103,10 +103,12 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
         return [
             (keymap.ACTIVATE,
              "Add an inline comment"),
+        ] + ([
             (keymap.NEXT_COMMIT,
              "Diff the next commit"),
             (keymap.PREV_COMMIT,
              "Diff the previous commit"),
+        ] if not self._multi_commit else []) + [
             (keymap.INTERACTIVE_SEARCH,
              "Interactive search"),
             (keymap.TOGGLE_DIFF_VIEW,
@@ -137,12 +139,14 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                                       self.repository_name),
         }
 
-    def __init__(self, app, new_commit_key):
+    def __init__(self, app, new_commit_key, old_commit_key=None,
+                 base_sha=None):
         super().__init__(urwid.Pile([]))
         self.log = logging.getLogger('hubtty.view.diff')
         self.app = app
-        self.old_commit_key = None  # Base
+        self.old_commit_key = old_commit_key
         self.new_commit_key = new_commit_key
+        self._explicit_base_sha = base_sha
         self.hide_generated = app.config.hide_generated_files
         self._init()
 
@@ -155,7 +159,18 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             new_comments = []
             self.old_file_keys = {}
             self.new_file_keys = {}
-            if self.old_commit_key is not None:
+            if self._explicit_base_sha is not None:
+                old_commit = None
+                self.base_sha = self._explicit_base_sha
+                show_old_commit = False
+                # Use the new commit's file info for old-side lookup,
+                # same as the single-commit case.
+                for f in new_commit.files:
+                    if f.old_path:
+                        self.old_file_keys[f.old_path] = f.key
+                    else:
+                        self.old_file_keys[f.path] = f.key
+            elif self.old_commit_key is not None:
                 old_commit = session.getCommit(self.old_commit_key)
                 self.base_sha = old_commit.sha
                 for f in old_commit.files:
@@ -174,11 +189,81 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                         self.old_file_keys[f.old_path] = f.key
                     else:
                         self.old_file_keys[f.path] = f.key
-            self.title = 'Diff of {} from {} to {}'.format(
-                new_commit.pull_request.repository.name,
-                new_commit.parent[0:7],
-                new_commit.sha[0:7])
-            self.short_title = f'Diff of {new_commit.sha[0:7]}'
+            repo_name = new_commit.pull_request.repository.name
+            pr = new_commit.pull_request
+            self._multi_commit = (self._explicit_base_sha is not None)
+            if self._multi_commit:
+                # Build commit summary for the range.
+                self._commit_summary = []
+                found_base = False
+                for c in pr.commits:
+                    if c.sha == self.base_sha:
+                        found_base = True
+                        continue
+                    if not found_base:
+                        continue
+                    self._commit_summary.append(
+                        (c.sha, c.message.split('\n')[0]))
+                    if c.key == self.new_commit_key:
+                        break
+                # If base_sha is the first commit's parent (full PR
+                # diff), include all commits up to new_commit.
+                if not self._commit_summary:
+                    for c in pr.commits:
+                        self._commit_summary.append(
+                            (c.sha, c.message.split('\n')[0]))
+                        if c.key == self.new_commit_key:
+                            break
+                # If still empty (data inconsistency), include all
+                # commits so we don't crash on an empty list.
+                if not self._commit_summary:
+                    self.log.warning(
+                        "Could not find commit %s in PR commits; "
+                        "showing all commits", self.new_commit_key)
+                    self._commit_summary = [
+                        (c.key, c.sha, c.message)
+                        for c in pr.commits]
+                n = len(self._commit_summary)
+                # A range that resolved to a single commit is
+                # effectively a normal single-commit view.
+                self._multi_commit = (n > 1)
+                if n == 1:
+                    # Single commit in range — use the normal
+                    # single-commit title format.
+                    subject = self._commit_summary[0][1]
+                    self.title = 'Diff of {} — {} {}'.format(
+                        repo_name,
+                        new_commit.sha[0:7], subject)
+                    self.short_title = f'Diff of {new_commit.sha[0:7]}'
+                else:
+                    self.title = 'Diff of {} — {}{}'.format(
+                        repo_name,
+                        '{} commits'.format(n),
+                        ' ({}..{})'.format(
+                            self.base_sha[0:7], new_commit.sha[0:7]))
+                    self.short_title = 'Diff {}..{}'.format(
+                        self.base_sha[0:7], new_commit.sha[0:7])
+            else:
+                subject = new_commit.message.split('\n')[0]
+                self._commit_summary = [
+                    (new_commit.sha, subject)]
+                self.title = 'Diff of {} — {} {}'.format(
+                    repo_name,
+                    new_commit.sha[0:7], subject)
+                self.short_title = f'Diff of {new_commit.sha[0:7]}'
+            # Compute 1-based positions within the full PR commit list.
+            all_shas = [c.sha for c in pr.commits]
+            self._total_commits = len(all_shas)
+            first_sha = self._commit_summary[0][0]
+            last_sha = self._commit_summary[-1][0]
+            try:
+                self._range_start = all_shas.index(first_sha) + 1
+            except ValueError:
+                self._range_start = 1
+            try:
+                self._range_end = all_shas.index(last_sha) + 1
+            except ValueError:
+                self._range_end = self._total_commits
             self.pr_key = new_commit.pull_request.key
             self.repository_name = new_commit.pull_request.repository.name
             self.sha = new_commit.sha
@@ -245,12 +330,32 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
         self.file_reminder = self.makeFileReminder()
         self._w.contents.append((self.file_reminder, ('pack', 1)))
         lines = []  # The initial set of lines to display
+        if self._commit_summary:
+            if self._range_start == self._range_end:
+                label = 'Commit (%d/%d):' % (
+                    self._range_start, self._total_commits)
+            else:
+                label = 'Commits (%d-%d/%d):' % (
+                    self._range_start, self._range_end,
+                    self._total_commits)
+            lines.append(urwid.Text(('filename', label)))
+            for sha, subject in self._commit_summary:
+                lines.append(urwid.Text(
+                    [('commit-sha', '  ' + sha[0:7]),
+                     ('commit-name', ' ' + subject)]))
+            lines.append(urwid.Text(''))
         self.file_diffs = [{}, {}]  # Mapping of fn -> DiffFile object (old, new)
         # this is a list of files:
         diffs = repo.diff(self.base_sha, self.sha,
                           show_old_commit=show_old_commit,
                           syntax_highlighting=self.app.config.syntax_highlighting,
                           max_highlight_size=self.app.config.max_highlight_size)
+        # Filter out synthetic /COMMIT_MSG entries that can appear in
+        # combined (multi-commit) diffs.  Harmless for single-commit
+        # diffs since git does not produce these entries.
+        diffs = [d for d in diffs
+                 if d.oldname != '/COMMIT_MSG'
+                 and d.newname != '/COMMIT_MSG']
         for diff in diffs:
             comment_filenames.discard(diff.oldname)
             comment_filenames.discard(diff.newname)
@@ -451,10 +556,12 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             (old_focus != new_focus or (keymap.PREV_SCREEN in commands))):
             self.cleanupEdit(old_focus)
         if keymap.NEXT_COMMIT in commands:
-            self.moveCommit(1)
+            if not self._multi_commit:
+                self.moveCommit(1)
             return None
         if keymap.PREV_COMMIT in commands:
-            self.moveCommit(-1)
+            if not self._multi_commit:
+                self.moveCommit(-1)
             return None
         if keymap.INTERACTIVE_SEARCH in commands:
             self.searchStart()
@@ -561,12 +668,17 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
         if config.diff_view == 'unified':
             config.diff_view = 'side-by-side'
             from hubtty.view.side_diff import SideDiffView
-            new_screen = SideDiffView(self.app, self.new_commit_key)
+            new_screen = SideDiffView(self.app, self.new_commit_key,
+                                      old_commit_key=self.old_commit_key,
+                                      base_sha=self._explicit_base_sha)
         else:
             config.diff_view = 'unified'
             from hubtty.view.unified_diff import UnifiedDiffView
-            new_screen = UnifiedDiffView(self.app, self.new_commit_key)
+            new_screen = UnifiedDiffView(self.app, self.new_commit_key,
+                                         old_commit_key=self.old_commit_key,
+                                         base_sha=self._explicit_base_sha)
         self.app.changeScreen(new_screen, push=False)
+
 
     def moveCommit(self, offset):
         commits = []
@@ -584,5 +696,8 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             return
         if commit_idx < 0:
             return
+        # Leave interdiff mode when navigating commits.
+        self.old_commit_key = None
+        self._explicit_base_sha = None
         self.new_commit_key = commits[commit_idx]
         self._init()

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -340,7 +340,14 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                 label = 'Commits (%d-%d/%d):' % (
                     self._range_start, self._range_end,
                     self._total_commits)
-            lines.append(urwid.Text(('filename', label)))
+            commit_label = mywid.TextButton(
+                ('filename', label),
+                on_press=lambda b: self.openInterdiffDialog())
+            commit_label._w = urwid.AttrMap(
+                commit_label.text, None,
+                focus_map={None: 'focused-filename',
+                           'filename': 'focused-filename'})
+            lines.append(commit_label)
             for sha, subject in self._commit_summary:
                 lines.append(urwid.Text(
                     [('commit-sha', '  ' + sha[0:7]),

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -115,6 +115,8 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
              "Toggle between unified and side-by-side diff"),
             (keymap.TOGGLE_GENERATED_FILES,
              "Toggle diff content of generated files"),
+            (keymap.INTERDIFF,
+             "Select commit range to diff"),
             ]
 
     def help(self):
@@ -573,6 +575,10 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
             self.app.input_buffer = []
             self.toggleGeneratedFiles()
             return None
+        if keymap.INTERDIFF in commands:
+            self.app.input_buffer = []
+            self.openInterdiffDialog()
+            return None
         if keymap.FURTHER_INPUT in commands:
             self.app.input_buffer = keys
             return None
@@ -679,6 +685,32 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                                          base_sha=self._explicit_base_sha)
         self.app.changeScreen(new_screen, push=False)
 
+    def openInterdiffDialog(self):
+        from hubtty.view.pull_request import InterdiffDialog
+        with self.app.db.getSession() as session:
+            pr = session.getPullRequest(self.pr_key)
+            if not pr.commits:
+                self.app.error('No commits synced for this pull request')
+                return
+            dialog = InterdiffDialog(self.app, pr)
+        urwid.connect_signal(dialog, 'cancel',
+            lambda button: self.app.backScreen())
+        urwid.connect_signal(dialog, 'diff',
+            lambda button: self._doInterdiff(dialog))
+        self.app.popup(dialog,
+                       relative_width=60, relative_height=50,
+                       min_width=40, min_height=12)
+
+    def _doInterdiff(self, dialog):
+        if not dialog.validate():
+            self.app.error('"From" must be before "To"')
+            return
+        old_commit_key, new_commit_key, base_sha = dialog.getValues()
+        self.app.backScreen()
+        self.old_commit_key = old_commit_key
+        self.new_commit_key = new_commit_key
+        self._explicit_base_sha = base_sha
+        self._init()
 
     def moveCommit(self, offset):
         commits = []

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -666,7 +666,7 @@ class PullRequestView(urwid.WidgetWrap):
     def getCommands(self):
         return [
             (keymap.DIFF,
-             "Show the diff of the first commit"),
+             "Diff this pull request (configurable via diff-default)"),
             (keymap.INTERDIFF,
              "Select commit range to diff"),
             (keymap.TOGGLE_HIDDEN,
@@ -1154,8 +1154,11 @@ class PullRequestView(urwid.WidgetWrap):
             row.review_button.openReview()
             return None
         if keymap.DIFF in commands:
-            row = self.commit_rows[self.first_commit_key]
-            row.diff(None)
+            if self.app.config.diff_default == 'full':
+                self.openFullDiff()
+            else:
+                row = self.commit_rows[self.first_commit_key]
+                row.diff(None)
             return None
         if keymap.INTERDIFF in commands:
             self.openInterdiffDialog()
@@ -1222,6 +1225,13 @@ class PullRequestView(urwid.WidgetWrap):
                 self.app, commit_key,
                 old_commit_key=old_commit_key, base_sha=base_sha)
         self.app.changeScreen(screen)
+
+    def openFullDiff(self):
+        with self.app.db.getSession() as session:
+            pr = session.getPullRequest(self.pr_key)
+            base_sha = pr.commits[0].parent
+            last_commit_key = pr.commits[-1].key
+        self.diff(last_commit_key, base_sha=base_sha)
 
     def openInterdiffDialog(self):
         with self.app.db.getSession() as session:

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -251,6 +251,122 @@ class EditPullRequestDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
         fill = urwid.Filler(pile, valign='top')
         super().__init__(urwid.LineBox(fill, 'Edit Pull Request'))
 
+class InterdiffDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
+    signals = ['diff', 'cancel']
+
+    def __init__(self, app, pr):
+        self.app = app
+        diff_button = mywid.FixedButton('Diff')
+        cancel_button = mywid.FixedButton('Cancel')
+        urwid.connect_signal(diff_button, 'click',
+            lambda button: self._emit('diff'))
+        urwid.connect_signal(cancel_button, 'click',
+            lambda button: self._emit('cancel'))
+
+        self.from_group = []
+        self.to_group = []
+        # Store commit data: list of (key, sha, first-line-of-message)
+        self.commits = []
+        # The parent of the first commit is the PR base.
+        self.base_sha = pr.commits[0].parent
+
+        for commit in pr.commits:
+            self.commits.append((
+                commit.key,
+                commit.sha,
+                commit.message.split('\n')[0],
+            ))
+
+        rows = []
+        rows.append(urwid.Text('From:'))
+        # "Base" option in the from-group (selected by default)
+        b = urwid.RadioButton(self.from_group,
+            'Base (%s)' % self.base_sha[0:7], state=True)
+        b._value = None  # sentinel: means "use base_sha"
+        rows.append(b)
+        for i, (key, sha, subject) in enumerate(self.commits):
+            label = '%s %s' % (sha[0:7], subject)
+            b = urwid.RadioButton(self.from_group, label, state=False)
+            b._value = i
+            rows.append(b)
+        rows.append(urwid.Divider())
+
+        rows.append(urwid.Text('To:'))
+        for i, (key, sha, subject) in enumerate(self.commits):
+            label = '%s %s' % (sha[0:7], subject)
+            is_last = (i == len(self.commits) - 1)
+            b = urwid.RadioButton(self.to_group, label, state=is_last)
+            b._value = i
+            rows.append(b)
+        rows.append(urwid.Divider())
+
+        button_widgets = [('pack', diff_button), ('pack', cancel_button)]
+        button_columns = urwid.Columns(button_widgets, dividechars=2)
+        rows.append(button_columns)
+        pile = urwid.Pile(rows)
+        fill = urwid.Filler(pile, valign='top')
+        super().__init__(urwid.LineBox(fill, 'Select Commit Range'))
+
+    def getValues(self):
+        """Return (old_commit_key_or_None, new_commit_key, base_sha_or_None).
+
+        When the user selects 'Base' as from, old_commit_key is None and
+        base_sha is the parent of the first commit.  Otherwise base_sha
+        is the sha of the selected from-commit.
+        """
+        from_idx = None
+        for button in self.from_group:
+            if button.state:
+                from_idx = button._value
+                break
+        to_idx = None
+        for button in self.to_group:
+            if button.state:
+                to_idx = button._value
+                break
+        if to_idx is None:
+            to_idx = len(self.commits) - 1
+
+        new_commit_key = self.commits[to_idx][0]
+
+        if from_idx is None:
+            # "Base" selected
+            return (None, new_commit_key, self.base_sha)
+        else:
+            old_commit_key = self.commits[from_idx][0]
+            base_sha = self.commits[from_idx][1]
+            return (old_commit_key, new_commit_key, base_sha)
+
+    def validate(self):
+        """Return True if the selection is valid (from < to)."""
+        from_idx = None
+        for button in self.from_group:
+            if button.state:
+                from_idx = button._value
+                break
+        to_idx = None
+        for button in self.to_group:
+            if button.state:
+                to_idx = button._value
+                break
+        if to_idx is None:
+            return False
+        if from_idx is None:
+            # Base is always before any commit
+            return True
+        return from_idx < to_idx
+
+    def keypress(self, size, key):
+        if not self.app.input_buffer:
+            key = super().keypress(size, key)
+        keys = self.app.input_buffer + [key]
+        commands = self.app.config.keymap.getCommands(keys)
+        if keymap.PREV_SCREEN in commands:
+            self._emit('cancel')
+            return None
+        return key
+
+
 class ReviewButton(mywid.FixedButton):
     def __init__(self, commit_row):
         super().__init__(('commit-button', 'Review'))

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -256,13 +256,6 @@ class InterdiffDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
 
     def __init__(self, app, pr):
         self.app = app
-        diff_button = mywid.FixedButton('Diff')
-        cancel_button = mywid.FixedButton('Cancel')
-        urwid.connect_signal(diff_button, 'click',
-            lambda button: self._emit('diff'))
-        urwid.connect_signal(cancel_button, 'click',
-            lambda button: self._emit('cancel'))
-
         self.from_group = []
         self.to_group = []
         # Store commit data: list of (key, sha, first-line-of-message)
@@ -277,28 +270,35 @@ class InterdiffDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
                 commit.message.split('\n')[0],
             ))
 
+        diff_button = mywid.FixedButton('Diff')
+        cancel_button = mywid.FixedButton('Cancel')
+        urwid.connect_signal(diff_button, 'click',
+            lambda button: self._emit('diff'))
+        urwid.connect_signal(cancel_button, 'click',
+            lambda button: self._emit('cancel'))
+
         rows = []
         rows.append(urwid.Text('From:'))
         # "Base" option in the from-group (selected by default)
         b = urwid.RadioButton(self.from_group,
             'Base (%s)' % self.base_sha[0:7], state=True)
         b._value = None  # sentinel: means "use base_sha"
+        urwid.connect_signal(b, 'change', self._fromChanged)
         rows.append(b)
-        for i, (key, sha, subject) in enumerate(self.commits):
+        # Exclude the last commit — it can never be a valid From
+        # because there are no later commits to select as To.
+        for i, (key, sha, subject) in enumerate(self.commits[:-1]):
             label = '%s %s' % (sha[0:7], subject)
             b = urwid.RadioButton(self.from_group, label, state=False)
             b._value = i
+            urwid.connect_signal(b, 'change', self._fromChanged)
             rows.append(b)
         rows.append(urwid.Divider())
 
-        rows.append(urwid.Text('To:'))
-        for i, (key, sha, subject) in enumerate(self.commits):
-            label = '%s %s' % (sha[0:7], subject)
-            is_last = (i == len(self.commits) - 1)
-            b = urwid.RadioButton(self.to_group, label, state=is_last)
-            b._value = i
-            rows.append(b)
-        rows.append(urwid.Divider())
+        # The To section is rebuilt dynamically when From changes.
+        self._to_pile = urwid.Pile([])
+        self._rebuildToGroup()
+        rows.append(self._to_pile)
 
         button_widgets = [('pack', diff_button), ('pack', cancel_button)]
         button_columns = urwid.Columns(button_widgets, dividechars=2)
@@ -307,6 +307,36 @@ class InterdiffDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
         fill = urwid.Filler(pile, valign='top')
         super().__init__(urwid.LineBox(fill, 'Select Commit Range'))
 
+    def _getFromIdx(self):
+        """Return the _value of the selected From button."""
+        for button in self.from_group:
+            if button.state:
+                return button._value
+        return None
+
+    def _fromChanged(self, button, state):
+        if state:  # Only rebuild when a button becomes selected.
+            self._rebuildToGroup(from_idx=button._value)
+
+    def _rebuildToGroup(self, from_idx=None):
+        min_to = 0 if from_idx is None else from_idx + 1
+
+        self.to_group = []
+        widgets = [urwid.Text('To:')]
+        for i in range(min_to, len(self.commits)):
+            key, sha, subject = self.commits[i]
+            label = '%s %s' % (sha[0:7], subject)
+            is_last = (i == len(self.commits) - 1)
+            b = urwid.RadioButton(self.to_group, label, state=is_last)
+            b._value = i
+            widgets.append(b)
+        widgets.append(urwid.Divider())
+
+        del self._to_pile.contents[:]
+        for w in widgets:
+            self._to_pile.contents.append(
+                (w, self._to_pile.options()))
+
     def getValues(self):
         """Return (old_commit_key_or_None, new_commit_key, base_sha_or_None).
 
@@ -314,11 +344,7 @@ class InterdiffDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
         base_sha is the parent of the first commit.  Otherwise base_sha
         is the sha of the selected from-commit.
         """
-        from_idx = None
-        for button in self.from_group:
-            if button.state:
-                from_idx = button._value
-                break
+        from_idx = self._getFromIdx()
         to_idx = None
         for button in self.to_group:
             if button.state:
@@ -338,23 +364,8 @@ class InterdiffDialog(urwid.WidgetWrap, mywid.LineBoxTitlePropertyMixin):
             return (old_commit_key, new_commit_key, base_sha)
 
     def validate(self):
-        """Return True if the selection is valid (from < to)."""
-        from_idx = None
-        for button in self.from_group:
-            if button.state:
-                from_idx = button._value
-                break
-        to_idx = None
-        for button in self.to_group:
-            if button.state:
-                to_idx = button._value
-                break
-        if to_idx is None:
-            return False
-        if from_idx is None:
-            # Base is always before any commit
-            return True
-        return from_idx < to_idx
+        """Return True if the selection is valid."""
+        return len(self.to_group) > 0
 
     def keypress(self, size, key):
         if not self.app.input_buffer:

--- a/hubtty/view/pull_request.py
+++ b/hubtty/view/pull_request.py
@@ -667,6 +667,8 @@ class PullRequestView(urwid.WidgetWrap):
         return [
             (keymap.DIFF,
              "Show the diff of the first commit"),
+            (keymap.INTERDIFF,
+             "Select commit range to diff"),
             (keymap.TOGGLE_HIDDEN,
              "Toggle the hidden flag for the current pull request"),
             (keymap.NEXT_PR,
@@ -1155,6 +1157,9 @@ class PullRequestView(urwid.WidgetWrap):
             row = self.commit_rows[self.first_commit_key]
             row.diff(None)
             return None
+        if keymap.INTERDIFF in commands:
+            self.openInterdiffDialog()
+            return None
         if keymap.SEARCH_RESULTS in commands:
             widget = self.app.findPullRequestList()
             if widget:
@@ -1207,12 +1212,40 @@ class PullRequestView(urwid.WidgetWrap):
             return None
         return key
 
-    def diff(self, commit_key):
+    def diff(self, commit_key, old_commit_key=None, base_sha=None):
         if self.app.config.diff_view == 'unified':
-            screen = view_unified_diff.UnifiedDiffView(self.app, commit_key)
+            screen = view_unified_diff.UnifiedDiffView(
+                self.app, commit_key,
+                old_commit_key=old_commit_key, base_sha=base_sha)
         else:
-            screen = view_side_diff.SideDiffView(self.app, commit_key)
+            screen = view_side_diff.SideDiffView(
+                self.app, commit_key,
+                old_commit_key=old_commit_key, base_sha=base_sha)
         self.app.changeScreen(screen)
+
+    def openInterdiffDialog(self):
+        with self.app.db.getSession() as session:
+            pr = session.getPullRequest(self.pr_key)
+            if not pr.commits:
+                self.app.error('No commits synced for this pull request')
+                return
+            dialog = InterdiffDialog(self.app, pr)
+        urwid.connect_signal(dialog, 'cancel',
+            lambda button: self.app.backScreen())
+        urwid.connect_signal(dialog, 'diff',
+            lambda button: self.doInterdiff(dialog))
+        self.app.popup(dialog,
+                       relative_width=60, relative_height=50,
+                       min_width=40, min_height=12)
+
+    def doInterdiff(self, dialog):
+        if not dialog.validate():
+            self.app.error('"From" must be before "To"')
+            return
+        old_commit_key, new_commit_key, base_sha = dialog.getValues()
+        self.app.backScreen()
+        self.diff(new_commit_key, old_commit_key=old_commit_key,
+                  base_sha=base_sha)
 
     def closePullRequest(self):
         dialog = mywid.TextEditDialog('Close pull request', 'Message:',


### PR DESCRIPTION
Allow selecting arbitrary ranges of commits within a PR to view a combined diff.
Bound to `D` by default in PR and diff views.

Introduce a new `diff-default` configuration option that allows selecting between `full` and `first-commit` (default).

Also rework the commit header in the diff view so it plays better with multi-commit diffs.

Fixes #93