### PR TITLE
Document generated-files in usage, reference config, and OpenShift example

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -59,6 +59,9 @@ a diff, press the `toggle diff view` key (`F2` in the default keymap,
 `td` in the vi keymap) to switch between the two layouts at runtime
 without changing the configuration file.
 
+To select text (e.g., to copy to the clipboard), hold Shift while
+selecting the text.
+
 Commit Range Diffs (Interdiff)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -79,5 +82,21 @@ The `diff-default` configuration option controls the default behavior
 of the `d` key in the pull request view (see the configuration
 documentation for details).
 
-To select text (e.g., to copy to the clipboard), hold Shift while
-selecting the text.
+Generated Files
+~~~~~~~~~~~~~~~
+
+Hubtty automatically detects generated files and collapses their diffs
+by default.  Generated files still appear in the diff view with their
+filename and a ``[generated]`` marker, but the diff chunks are hidden.
+In the pull request view, generated files are grouped into a single
+summary row.
+
+Press ``G`` (or ``t g`` in vi mode) in the diff view to toggle
+expansion of generated file diffs.
+
+Generated files are identified from three sources: ``.gitattributes``
+entries with ``linguist-generated``, built-in heuristic patterns for
+commonly generated files (lock files, protobuf output, minified assets,
+etc.), and user-supplied glob patterns.  See the ``hide-generated-files``
+and ``generated-files`` options in the configuration documentation for
+details.

--- a/examples/openshift-hubtty.yaml
+++ b/examples/openshift-hubtty.yaml
@@ -216,6 +216,14 @@ commentlinks:
 # Default is 524288 (512 KiB).
 # max-highlight-size: 524288
 
+# Collapse diffs for common Kubernetes / OpenShift generated files.
+# The built-in heuristics already cover go.sum and several other
+# lock files; the patterns below add k8s code-generator output.
+generated-files:
+  - "zz_generated.*.go"
+  - "pkg/clients/**/*.go"
+  - "config/crd/bases/*.yaml"
+
 # Times are displayed in the local timezone by default.  To display
 # them in UTC instead, uncomment the following line:
 # display-times-in-utc: true

--- a/examples/reference-hubtty.yaml
+++ b/examples/reference-hubtty.yaml
@@ -209,6 +209,31 @@ commentlinks:
 # Default is 524288 (512 KiB).
 # max-highlight-size: 524288
 
+# Generated files are collapsed by default in diff views: the filename
+# and a [generated] marker are shown but the diff chunks are hidden.
+# In the pull request view, generated files are grouped into a single
+# summary row.
+#
+# Generated files are detected from three sources:
+#   - .gitattributes entries with linguist-generated (as used by GitHub).
+#     A linguist-generated=false entry takes highest precedence and can
+#     un-mark a file.
+#   - Built-in heuristic patterns for commonly generated files (lock
+#     files, protobuf output, minified assets, etc.).
+#   - User-supplied patterns via the generated-files option below.
+#
+# To show generated file diffs expanded by default, uncomment:
+# hide-generated-files: false
+
+# Additional glob patterns identifying generated files beyond the
+# built-in heuristics and .gitattributes markers.  Patterns without a
+# '/' are matched against the basename; patterns with a '/' are matched
+# against the full path ('*' matches within a path component, '**'
+# matches across components).
+# generated-files:
+#   - "*.snap"
+#   - "generated/**"
+
 # Times are displayed in the local timezone by default.  To display
 # them in UTC instead, uncomment the following line:
 # display-times-in-utc: true


### PR DESCRIPTION
Add a Generated Files section to usage.rst describing auto-detection, the [generated] marker, summary row in PR view.

Add hide-generated-files and generated-files entries to reference-hubtty.yaml with full commentary on detection sources and pattern matching semantics.

Add active generated-files patterns to openshift-hubtty.yaml for common Kubernetes generated files (zz_generated.*.go, generated clients, CRD bases).